### PR TITLE
feat(phase4-pr1): add ThemePreferenceToDisplayNameConverter

### DIFF
--- a/src/AStar.Dev.OneDrive.Client/Converters/ThemePreferenceToDisplayNameConverter.cs
+++ b/src/AStar.Dev.OneDrive.Client/Converters/ThemePreferenceToDisplayNameConverter.cs
@@ -1,0 +1,35 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Client.Core.Models.Enums;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace AStar.Dev.OneDrive.Client.Converters;
+
+/// <summary>
+/// Converts ThemePreference enum values to user-friendly display names.
+/// </summary>
+public class ThemePreferenceToDisplayNameConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not ThemePreference theme)
+            return "Unknown";
+
+        return theme switch
+        {
+            ThemePreference.OriginalAuto => "Original (Automatic)",
+            ThemePreference.OriginalLight => "Original (Light)",
+            ThemePreference.OriginalDark => "Original (Dark)",
+            ThemePreference.Professional => "Professional",
+            ThemePreference.Colourful => "Colourful",
+            ThemePreference.Terminal => "Terminal / Hacker",
+            _ => "Unknown"
+        };
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        // Not supported
+        return BindingNotification.UnsetValue;
+    }
+}

--- a/test/AStar.Dev.OneDrive.Client.Tests.Unit/Converters/ThemePreferenceToDisplayNameConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Client.Tests.Unit/Converters/ThemePreferenceToDisplayNameConverterShould.cs
@@ -1,0 +1,48 @@
+using AStar.Dev.OneDrive.Client.Converters;
+using AStar.Dev.OneDrive.Client.Core.Models.Enums;
+using Avalonia.Data.Converters;
+using Shouldly;
+
+namespace AStar.Dev.OneDrive.Client.Tests.Unit.Converters;
+
+public class ThemePreferenceToDisplayNameConverterShould
+{
+    private readonly IValueConverter _sut = new ThemePreferenceToDisplayNameConverter();
+
+    [Theory]
+    [InlineData(ThemePreference.OriginalAuto, "Original (Automatic)")]
+    [InlineData(ThemePreference.OriginalLight, "Original (Light)")]
+    [InlineData(ThemePreference.OriginalDark, "Original (Dark)")]
+    [InlineData(ThemePreference.Professional, "Professional")]
+    [InlineData(ThemePreference.Colourful, "Colourful")]
+    [InlineData(ThemePreference.Terminal, "Terminal / Hacker")]
+    public void Convert_ReturnDisplayNameForThemePreference(ThemePreference theme, string expectedName)
+    {
+        // Act
+        var result = _sut.Convert(theme, typeof(string), null, System.Globalization.CultureInfo.CurrentCulture);
+
+        // Assert
+        result.ShouldBe(expectedName);
+    }
+
+    [Fact]
+    public void Convert_ReturnUnknownForNullValue()
+    {
+        // Act
+        var result = _sut.Convert(null, typeof(string), null, System.Globalization.CultureInfo.CurrentCulture);
+
+        // Assert
+        result.ShouldBe("Unknown");
+    }
+
+    [Fact]
+    public void ConvertBack_NotSupported()
+    {
+        // Act
+        var result = _sut.ConvertBack("Original (Automatic)", typeof(ThemePreference), null, System.Globalization.CultureInfo.CurrentCulture);
+
+        // Assert
+        result.ShouldBe(Avalonia.Data.BindingNotification.UnsetValue);
+    }
+}
+


### PR DESCRIPTION
## Summary

Phase 4 Part 1: Implements value converter for mapping ThemePreference enum values to user-friendly display names. This converter will be used in the SettingsWindow ComboBox for theme selection.

## Changes

- **ThemePreferenceToDisplayNameConverter** (new): IValueConverter implementation
  - Maps all 6 theme enum values to display strings
  - Returns "Unknown" for null values
  - ConvertBack not supported (read-only converter)

## Enum Mapping

| Enum Value | Display Name |
|---|---|
| OriginalAuto | Original (Automatic) |
| OriginalLight | Original (Light) |
| OriginalDark | Original (Dark) |
| Professional | Professional |
| Colourful | Colourful |
| Terminal | Terminal / Hacker |

## Testing

- ✅ 8 unit tests passing (6 enum value mappings + null + ConvertBack)
- ✅ All tests follow TDD: RED → GREEN → REFACTOR
- ✅ Build succeeded with no errors/warnings

## TDD Cycle

1. **RED**: Created failing test asserting converter mapping behavior
2. **GREEN**: Implemented minimal converter to make all 8 tests pass
3. **REFACTOR**: Converter is optimal as-is (simple switch expression)

## Next Steps

- PR2: SettingsViewModel + unit tests
- PR3: SettingsWindow XAML
- PR4: Menu integration