### PR TITLE
feat(phase4-pr4): integrate Settings menu and OpenSettingsCommand

### DIFF
--- a/src/AStar.Dev.OneDrive.Client/MainWindow/MainWindow.axaml
+++ b/src/AStar.Dev.OneDrive.Client/MainWindow/MainWindow.axaml
@@ -33,6 +33,8 @@
                           Command="{Binding OpenViewSyncHistoryCommand}" />
                 <MenuItem Header="_View Debug Logs"
                           Command="{Binding OpenDebugLogViewerCommand}" />
+                <MenuItem Header="_Settings..."
+                          Command="{Binding OpenSettingsCommand}" />
                 <Separator />
                 <MenuItem Header="_Close Application"
                           Command="{Binding CloseApplicationCommand}"

--- a/src/AStar.Dev.OneDrive.Client/MainWindow/MainWindowViewModel.cs
+++ b/src/AStar.Dev.OneDrive.Client/MainWindow/MainWindowViewModel.cs
@@ -235,7 +235,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IDisposable
             DataContext = settingsViewModel
         };
 
-        if (Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime
+        if(Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime
             {
                 MainWindow: not null
             } desktop)

--- a/src/AStar.Dev.OneDrive.Client/MainWindow/MainWindowViewModel.cs
+++ b/src/AStar.Dev.OneDrive.Client/MainWindow/MainWindowViewModel.cs
@@ -53,6 +53,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IDisposable
         OpenUpdateAccountDetailsCommand = ReactiveCommand.Create(OpenUpdateAccountDetails);
         OpenViewSyncHistoryCommand = ReactiveCommand.Create(OpenViewSyncHistory);
         OpenDebugLogViewerCommand = ReactiveCommand.Create(OpenDebugLogViewer);
+        OpenSettingsCommand = ReactiveCommand.Create(OpenSettings);
         ViewConflictsCommand = ReactiveCommand.Create(ViewConflicts, this.WhenAnyValue(x => x.HasUnresolvedConflicts));
         CloseApplicationCommand = ReactiveCommand.Create(CloseApplication);
         _ = DebugLog.EntryAsync(DebugLogMetadata.UI.MainWindowViewModel.Constructor, AccountManagement.SelectedAccount?.AccountId ?? AdminAccountMetadata.AccountId, CancellationToken.None);
@@ -91,6 +92,8 @@ public sealed class MainWindowViewModel : ReactiveObject, IDisposable
     public ReactiveCommand<Unit, Unit> OpenViewSyncHistoryCommand { get; }
 
     public ReactiveCommand<Unit, Unit> OpenDebugLogViewerCommand { get; }
+
+    public ReactiveCommand<Unit, Unit> OpenSettingsCommand { get; }
 
     public ReactiveCommand<Unit, Unit> ViewConflictsCommand { get; }
 
@@ -224,7 +227,22 @@ public sealed class MainWindowViewModel : ReactiveObject, IDisposable
             _ = window.ShowDialog(desktop.MainWindow);
         }
     }
+    private void OpenSettings()
+    {
+        var settingsViewModel = _serviceProvider.GetRequiredService<Settings.SettingsViewModel>();
+        var window = new Settings.SettingsWindow
+        {
+            DataContext = settingsViewModel
+        };
 
+        if (Avalonia.Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime
+            {
+                MainWindow: not null
+            } desktop)
+        {
+            _ = window.ShowDialog(desktop.MainWindow);
+        }
+    }
     private void WireUpTheAccountManagentViewModel(AccountManagementViewModel accountManagementViewModel, SyncTreeViewModel syncTreeViewModel)
     {
         _ = accountManagementViewModel

--- a/src/AStar.Dev.OneDrive.Client/Settings/SettingsViewModel.cs
+++ b/src/AStar.Dev.OneDrive.Client/Settings/SettingsViewModel.cs
@@ -1,5 +1,6 @@
 using AStar.Dev.OneDrive.Client.Core.Models.Enums;
 using AStar.Dev.OneDrive.Client.Infrastructure.Services;
+using AStar.Dev.Source.Generators.Attributes;
 using ReactiveUI;
 using System.Windows.Input;
 
@@ -8,6 +9,7 @@ namespace AStar.Dev.OneDrive.Client.Settings;
 /// <summary>
 /// ViewModel for the Settings window, providing theme selection and application.
 /// </summary>
+[AutoRegisterService]
 public class SettingsViewModel : ReactiveObject
 {
     private readonly IThemeService _themeService;

--- a/src/nuget-packages/AStar.Dev.Logging.Extensions/SerilogConfigure.cs
+++ b/src/nuget-packages/AStar.Dev.Logging.Extensions/SerilogConfigure.cs
@@ -16,10 +16,11 @@ internal static class SerilogConfigure
     /// <param name="configuration">The application configuration containing Serilog settings.</param>
     /// <param name="telemetryConfiguration">The Application Insights telemetry configuration.</param>
     /// <returns>The configured <see cref="LoggerConfiguration" /> instance.</returns>
-    public static LoggerConfiguration Configure(this LoggerConfiguration loggerConfiguration, IConfiguration configuration, TelemetryConfiguration telemetryConfiguration) => loggerConfiguration
+    public static LoggerConfiguration Configure(this LoggerConfiguration loggerConfiguration, IConfiguration configuration, TelemetryConfiguration telemetryConfiguration)
+        => loggerConfiguration
                 .WriteTo.ApplicationInsights(telemetryConfiguration,
                     TelemetryConverter.Traces)
-                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {Message:lj}{NewLine}{Exception}")
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level}] {Message:lj}{NewLine}{Exception}", formatProvider: new System.Globalization.CultureInfo("en-GB"))
                 .ReadFrom.Configuration(configuration);
 #pragma warning restore CA1305 // Specify IFormatProvider
 }

--- a/test/AStar.Dev.OneDrive.Client.Tests.Unit/MainWindow/MainWindowViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Client.Tests.Unit/MainWindow/MainWindowViewModelShould.cs
@@ -134,6 +134,21 @@ public class MainWindowViewModelShould
         Should.NotThrow(sut.Dispose);
     }
 
+    [Fact]
+    public void HaveOpenSettingsCommandInitialized()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.OpenSettingsCommand.ShouldNotBeNull();
+    }
+
     private static AccountManagementViewModel CreateAccountManagementViewModel()
     {
         IAuthService mockAuth = Substitute.For<IAuthService>();


### PR DESCRIPTION
- Add OpenSettingsCommand property to MainWindowViewModel
- Implement OpenSettings() method to create and show SettingsWindow
- Inject SettingsViewModel from DI with AutoRegisterService attribute
- Add Settings menu item in MainWindow.axaml File menu (Alt+S shortcut)
- Create SettingsWindow with DataContext bound to SettingsViewModel
- Add unit test for OpenSettingsCommand initialization
- Settings dialog opens as modal centered on main window

TDD: RED (command missing) -> GREEN (test pass) -> COMMIT
Completes Phase 4: Settings UI menu integration
