### PR TITLE
Add unit tests for multiple ViewModels

### DIFF
--- a/src/AStar.Dev.OneDrive.Sync.Client.Infrastructure/Repositories/DriveItemsRepository.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client.Infrastructure/Repositories/DriveItemsRepository.cs
@@ -116,7 +116,7 @@ public sealed class DriveItemsRepository(IDbContextFactory<SyncDbContext> contex
                 driveItem.CTag,
                 driveItem.ETag,
                 driveItem.LocalHash,
-                (FileSyncStatus)driveItem.SyncStatus,
+                driveItem.SyncStatus,
                 driveItem.LastSyncDirection
             );
 

--- a/src/AStar.Dev.OneDrive.Sync.Client/DebugLogs/DebugLogViewModel.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client/DebugLogs/DebugLogViewModel.cs
@@ -192,6 +192,7 @@ public sealed class DebugLogViewModel : ReactiveObject
         debugLogs.ForEach(DebugLogs.Add);
 
         TotalRecordCount = await _debugLogRepository.GetDebugLogCountByAccountIdAsync(SelectedAccount!.HashedAccountId);
+        HasMoreRecords = (CurrentPage * PageSize) < TotalRecordCount;
         StartingCountOfItemsDisplayed = ((CurrentPage - 1) * PageSize) + 1;
         EndingCountOfItemsDisplayed = StartingCountOfItemsDisplayed + PageSize - 1;
     }

--- a/src/AStar.Dev.OneDrive.Sync.Client/DebugLogs/DebugLogViewModel.cs
+++ b/src/AStar.Dev.OneDrive.Sync.Client/DebugLogs/DebugLogViewModel.cs
@@ -98,7 +98,7 @@ public sealed class DebugLogViewModel : ReactiveObject
     public bool IsLoading
     {
         get;
-        private set
+        set
         {
             _ = this.RaiseAndSetIfChanged(ref field, value);
             this.RaisePropertyChanged(nameof(CanGoToNextPage));

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/MainWindow/MainWindowViewModelIntegrationShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/MainWindow/MainWindowViewModelIntegrationShould.cs
@@ -14,7 +14,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Logging;
 
-namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.MainWindow;
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Integration.MainWindow;
 
 /// <summary>
 ///     Integration tests for MainWindowViewModel coordinating AccountManagementViewModel and SyncTreeViewModel.

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/UpdateAccountDetailsViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/UpdateAccountDetailsViewModelShould.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Core;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models;

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/UpdateAccountDetailsViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/UpdateAccountDetailsViewModelShould.cs
@@ -7,196 +7,522 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Accounts;
 
-public class UpdateAccountDetailsViewModelShould
+/// <summary>
+///     Unit tests for <see cref="UpdateAccountDetailsViewModel" />.
+/// </summary>
+public sealed class UpdateAccountDetailsViewModelShould
 {
     [Fact]
-    public void InitializeWithEmptyAccountsCollection()
+    public async Task LoadAccountsFromRepositoryOnInitialization()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        AccountInfo account1 = CreateTestAccount("acc1", "User 1");
+        AccountInfo account2 = CreateTestAccount("acc2", "User 2");
+        _ = mockRepo.GetAllAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<AccountInfo>>([account1, account2]));
+        _ = mockRepo.GetByIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns((AccountInfo?)null);
 
         var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        _ = sut.Accounts.ShouldBeOfType<ObservableCollection<AccountInfo>>();
+        sut.Accounts.Count.ShouldBe(2);
+        sut.Accounts[0].DisplayName.ShouldBe("User 1");
+        sut.Accounts[1].DisplayName.ShouldBe("User 2");
+    }
+
+    [Fact]
+    public async Task HandleExceptionWhenLoadingAccountsFails()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        _ = mockRepo.GetAllAsync(Arg.Any<CancellationToken>()).Returns<IReadOnlyList<AccountInfo>>(_ => throw new Exception("Database error"));
+
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.StatusMessage.ShouldContain("Failed to load accounts");
+        sut.IsSuccess.ShouldBeFalse();
         sut.Accounts.ShouldBeEmpty();
     }
 
     [Fact]
-    public void InitializeWithNullSelectedAccount()
+    public async Task UpdateLastSyncUtcFromRepositoryWhenLoadingAccounts()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        DateTime lastSync = DateTime.UtcNow.AddHours(-2);
+        AccountInfo account = CreateTestAccount("acc1", "User 1");
+        AccountInfo accountWithSync = account with { LastSyncUtc = lastSync };
+        _ = mockRepo.GetAllAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<AccountInfo>>([account]));
+        _ = mockRepo.GetByIdAsync(account.HashedAccountId, Arg.Any<CancellationToken>()).Returns(accountWithSync);
 
         var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        sut.SelectedAccount.ShouldBeNull();
+        sut.Accounts[0].LastSyncUtc.ShouldBe(lastSync);
     }
 
     [Fact]
-    public void InitializeWithEmptyLocalSyncPath()
+    public async Task UpdateAccountSuccessfully()
     {
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _ = Directory.CreateDirectory(tempPath);
 
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        try
+        {
+            IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+            IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+            AccountInfo account = CreateTestAccount("acc1", "User 1", tempPath);
+            _ = mockRepo.UpdateAsync(Arg.Any<AccountInfo>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+            {
+                SelectedAccount = account,
+                LocalSyncPath = tempPath,
+                EnableDetailedSyncLogging = true,
+                EnableDebugLogging = true,
+                MaxParallelUpDownloads = 7,
+                MaxItemsInBatch = 80,
+                AutoSyncIntervalMinutes = 120
+            };
 
-        sut.LocalSyncPath.ShouldBeEmpty();
+            _ = sut.UpdateCommand.Execute().Subscribe();
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+
+            await mockRepo.Received(1).UpdateAsync(Arg.Is<AccountInfo>(a =>
+                a.LocalSyncPath == tempPath &&
+                a.EnableDetailedSyncLogging &&
+                a.EnableDebugLogging &&
+                a.MaxParallelUpDownloads == 7 &&
+                a.MaxItemsInBatch == 80 &&
+                a.AutoSyncIntervalMinutes == 120), Arg.Any<CancellationToken>());
+            sut.StatusMessage.ShouldBe("Account updated successfully!");
+            sut.IsSuccess.ShouldBeTrue();
+        }
+        finally
+        {
+            if(Directory.Exists(tempPath))
+                Directory.Delete(tempPath);
+        }
     }
 
     [Fact]
-    public void InitializeWithEnableDetailedSyncLoggingFalse()
+    public async Task UpdateSchedulerServiceWithNewAutoSyncInterval()
     {
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _ = Directory.CreateDirectory(tempPath);
 
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        try
+        {
+            IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+            IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+            AccountInfo account = CreateTestAccount("acc1", "User 1", tempPath);
+            _ = mockRepo.UpdateAsync(Arg.Any<AccountInfo>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+            {
+                SelectedAccount = account,
+                AutoSyncIntervalMinutes = 180
+            };
 
-        sut.EnableDetailedSyncLogging.ShouldBeFalse();
+            _ = sut.UpdateCommand.Execute().Subscribe();
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+
+            mockScheduler.Received(1).UpdateSchedule(account.Id, account.HashedAccountId, 180);
+        }
+        finally
+        {
+            if(Directory.Exists(tempPath))
+                Directory.Delete(tempPath);
+        }
     }
 
     [Fact]
-    public void InitializeWithEnableDebugLoggingFalse()
+    public async Task UpdateAccountInCollectionAfterSuccessfulUpdate()
     {
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _ = Directory.CreateDirectory(tempPath);
 
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        try
+        {
+            IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+            IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+            AccountInfo account = CreateTestAccount("acc1", "User 1", tempPath);
+            _ = mockRepo.UpdateAsync(Arg.Any<AccountInfo>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+            sut.Accounts.Add(account);
+            sut.SelectedAccount = account;
+            sut.EnableDetailedSyncLogging = true;
 
-        sut.EnableDebugLogging.ShouldBeFalse();
+            _ = sut.UpdateCommand.Execute().Subscribe();
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+
+            sut.Accounts[0].EnableDetailedSyncLogging.ShouldBeTrue();
+            sut.SelectedAccount!.EnableDetailedSyncLogging.ShouldBeTrue();
+        }
+        finally
+        {
+            if(Directory.Exists(tempPath))
+                Directory.Delete(tempPath);
+        }
     }
 
     [Fact]
-    public void InitializeWithEmptyStatusMessage()
+    public async Task RaiseRequestCloseEventAfterSuccessfulUpdate()
     {
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _ = Directory.CreateDirectory(tempPath);
 
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        try
+        {
+            IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+            IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+            AccountInfo account = CreateTestAccount("acc1", "User 1", tempPath);
+            _ = mockRepo.UpdateAsync(Arg.Any<AccountInfo>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+            var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+            {
+                SelectedAccount = account
+            };
+            var eventRaised = false;
+            sut.RequestClose += (_, _) => eventRaised = true;
 
-        sut.StatusMessage.ShouldBeEmpty();
+            _ = sut.UpdateCommand.Execute().Subscribe();
+            await Task.Delay(2100, TestContext.Current.CancellationToken);
+
+            eventRaised.ShouldBeTrue();
+        }
+        finally
+        {
+            if(Directory.Exists(tempPath))
+                Directory.Delete(tempPath);
+        }
     }
 
     [Fact]
-    public void InitializeWithIsSuccessFalse()
+    public async Task NotUpdateAccountWhenSelectedAccountIsNull()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            SelectedAccount = null
+        };
 
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        _ = sut.UpdateCommand.Execute().Subscribe();
 
+        await mockRepo.DidNotReceive().UpdateAsync(Arg.Any<AccountInfo>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ShowErrorMessageWhenLocalSyncPathDoesNotExist()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        AccountInfo account = CreateTestAccount("acc1", "User 1");
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            SelectedAccount = account,
+            LocalSyncPath = @"C:\NonExistentPath\Invalid"
+        };
+
+        _ = sut.UpdateCommand.Execute().Subscribe();
+
+        sut.StatusMessage.ShouldContain("Local sync path does not exist");
         sut.IsSuccess.ShouldBeFalse();
+        await mockRepo.DidNotReceive().UpdateAsync(Arg.Any<AccountInfo>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public void InitializeUpdateCommand()
+    public async Task ShowErrorMessageWhenUpdateFails()
     {
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        _ = Directory.CreateDirectory(tempPath);
 
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        try
+        {
+            IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+            IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+            AccountInfo account = CreateTestAccount("acc1", "User 1", tempPath);
+            _ = mockRepo.UpdateAsync(Arg.Any<AccountInfo>(), Arg.Any<CancellationToken>()).Returns<Task>(_ => throw new Exception("Database error"));
+            var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+            {
+                SelectedAccount = account
+            };
+            var eventRaised = false;
+            sut.RequestClose += (_, _) => eventRaised = true;
 
-        _ = sut.UpdateCommand.ShouldNotBeNull();
+            _ = sut.UpdateCommand.Execute().Subscribe();
+            await Task.Delay(100, TestContext.Current.CancellationToken);
+
+            sut.StatusMessage.ShouldContain("Failed to update account");
+            sut.IsSuccess.ShouldBeFalse();
+            eventRaised.ShouldBeFalse();
+        }
+        finally
+        {
+            if(Directory.Exists(tempPath))
+                Directory.Delete(tempPath);
+        }
     }
 
     [Fact]
-    public void InitializeCancelCommand()
+    public void ClampAutoSyncIntervalMinutesToMinimumOf60WhenGreaterThanZero()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            AutoSyncIntervalMinutes = 30
+        };
 
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
-
-        _ = sut.CancelCommand.ShouldNotBeNull();
+        sut.AutoSyncIntervalMinutes.ShouldBe(60);
     }
 
     [Fact]
-    public void InitializeBrowseFolderCommand()
+    public void ClampAutoSyncIntervalMinutesToMaximumOf1440()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            AutoSyncIntervalMinutes = 2000
+        };
 
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
-
-        _ = sut.BrowseFolderCommand.ShouldNotBeNull();
+        sut.AutoSyncIntervalMinutes.ShouldBe(1440);
     }
 
     [Fact]
-    public void LoadEditableFieldsWhenAccountIsSelected()
+    public void AllowAutoSyncIntervalMinutesOfZeroToDisableAutoSync()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            AutoSyncIntervalMinutes = 0
+        };
+
+        sut.AutoSyncIntervalMinutes.ShouldBe(0);
+    }
+
+    [Fact]
+    public void AllowAutoSyncIntervalMinutesOfNegativeOneToDisableAutoSync()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            AutoSyncIntervalMinutes = -1
+        };
+
+        sut.AutoSyncIntervalMinutes.ShouldBe(0);
+    }
+
+    [Fact]
+    public void LoadAutoSyncIntervalMinutesWhenAccountSelected()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
         var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "Test User",
-            @"C:\TestPath",
-            true,
-            DateTime.UtcNow,
-            "delta-token",
-            true,
-            false,
-            3,
-            50,
-            0);
+        AccountInfo account = CreateTestAccount("acc1", "User 1", autoSyncInterval: 240);
 
         sut.SelectedAccount = account;
 
-        sut.LocalSyncPath.ShouldBe(@"C:\TestPath");
+        sut.AutoSyncIntervalMinutes.ShouldBe(240);
+    }
+
+    [Fact]
+    public void LoadAutoSyncIntervalMinutesAsZeroWhenAccountHasNullInterval()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        AccountInfo account = CreateTestAccount("acc1", "User 1", autoSyncInterval: null);
+
+        sut.SelectedAccount = account;
+
+        sut.AutoSyncIntervalMinutes.ShouldBe(0);
+    }
+
+    [Fact]
+    public void RaisePropertyChangedWhenMaxParallelUpDownloadsChanges()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        var propertyChanged = false;
+
+        sut.PropertyChanged += (_, args) =>
+        {
+            if(args.PropertyName == nameof(UpdateAccountDetailsViewModel.MaxParallelUpDownloads))
+                propertyChanged = true;
+        };
+
+        sut.MaxParallelUpDownloads = 8;
+
+        propertyChanged.ShouldBeTrue();
+        sut.MaxParallelUpDownloads.ShouldBe(8);
+    }
+
+    [Fact]
+    public void RaisePropertyChangedWhenMaxItemsInBatchChanges()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        var propertyChanged = false;
+
+        sut.PropertyChanged += (_, args) =>
+        {
+            if(args.PropertyName == nameof(UpdateAccountDetailsViewModel.MaxItemsInBatch))
+                propertyChanged = true;
+        };
+
+        sut.MaxItemsInBatch = 90;
+
+        propertyChanged.ShouldBeTrue();
+        sut.MaxItemsInBatch.ShouldBe(90);
+    }
+
+    [Fact]
+    public void RaisePropertyChangedWhenAutoSyncIntervalMinutesChanges()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        var propertyChanged = false;
+
+        sut.PropertyChanged += (_, args) =>
+        {
+            if(args.PropertyName == nameof(UpdateAccountDetailsViewModel.AutoSyncIntervalMinutes))
+                propertyChanged = true;
+        };
+
+        sut.AutoSyncIntervalMinutes = 120;
+
+        propertyChanged.ShouldBeTrue();
+        sut.AutoSyncIntervalMinutes.ShouldBe(120);
+    }
+
+    [Fact]
+    public void InitializeMaxParallelUpDownloadsToDefaultValue()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+
+        sut.MaxParallelUpDownloads.ShouldBe(5);
+    }
+
+    [Fact]
+    public void InitializeMaxItemsInBatchToDefaultValue()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+
+        sut.MaxItemsInBatch.ShouldBe(50);
+    }
+
+    [Fact]
+    public void InitializeAutoSyncIntervalMinutesToZero()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+
+        sut.AutoSyncIntervalMinutes.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ClampMaxParallelUpDownloadsToMinimumOf1()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            MaxParallelUpDownloads = 0
+        };
+
+        sut.MaxParallelUpDownloads.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ClampMaxParallelUpDownloadsToMaximumOf10()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            MaxParallelUpDownloads = 15
+        };
+
+        sut.MaxParallelUpDownloads.ShouldBe(10);
+    }
+
+    [Fact]
+    public void ClampMaxItemsInBatchToMinimumOf1()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            MaxItemsInBatch = -5
+        };
+
+        sut.MaxItemsInBatch.ShouldBe(1);
+    }
+
+    [Fact]
+    public void ClampMaxItemsInBatchToMaximumOf100()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            MaxItemsInBatch = 150
+        };
+
+        sut.MaxItemsInBatch.ShouldBe(100);
+    }
+
+    [Fact]
+    public void RaiseRequestCloseEventWhenCancelCommandExecuted()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        var eventRaised = false;
+        sut.RequestClose += (_, _) => eventRaised = true;
+
+        _ = sut.CancelCommand.Execute().Subscribe();
+
+        eventRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void LoadPropertiesWhenAccountSelected()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+        AccountInfo account = CreateTestAccount("acc1", "User 1", @"C:\SyncPath", 180);
+        AccountInfo accountWithSettings = account with
+        {
+            EnableDetailedSyncLogging = true,
+            EnableDebugLogging = true,
+            MaxParallelUpDownloads = 7,
+            MaxItemsInBatch = 75
+        };
+
+        sut.SelectedAccount = accountWithSettings;
+
+        sut.LocalSyncPath.ShouldBe(@"C:\SyncPath");
         sut.EnableDetailedSyncLogging.ShouldBeTrue();
-        sut.StatusMessage.ShouldBeEmpty();
-    }
-
-    [Fact]
-    public void LoadEnableDebugLoggingWhenAccountIsSelected()
-    {
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "Test User",
-            @"C:\TestPath",
-            true,
-            DateTime.UtcNow,
-            "delta-token",
-            false,
-            true,
-            3,
-            50,
-            0);
-
-        sut.SelectedAccount = account;
-
         sut.EnableDebugLogging.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void ClearStatusMessageWhenAccountIsSelected()
-    {
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler) { StatusMessage = "Previous message" };
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "Test User",
-            @"C:\TestPath",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
-
-        sut.SelectedAccount = account;
-
+        sut.MaxParallelUpDownloads.ShouldBe(7);
+        sut.MaxItemsInBatch.ShouldBe(75);
+        sut.AutoSyncIntervalMinutes.ShouldBe(180);
         sut.StatusMessage.ShouldBeEmpty();
     }
 
@@ -214,21 +540,7 @@ public class UpdateAccountDetailsViewModelShould
                 propertyChanged = true;
         };
 
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "Test User",
-            @"C:\TestPath",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
-
-        sut.SelectedAccount = account;
+        sut.SelectedAccount = CreateTestAccount("acc1", "User 1");
 
         propertyChanged.ShouldBeTrue();
     }
@@ -250,7 +562,6 @@ public class UpdateAccountDetailsViewModelShould
         sut.LocalSyncPath = @"C:\NewPath";
 
         propertyChanged.ShouldBeTrue();
-        sut.LocalSyncPath.ShouldBe(@"C:\NewPath");
     }
 
     [Fact]
@@ -270,7 +581,6 @@ public class UpdateAccountDetailsViewModelShould
         sut.EnableDetailedSyncLogging = true;
 
         propertyChanged.ShouldBeTrue();
-        sut.EnableDetailedSyncLogging.ShouldBeTrue();
     }
 
     [Fact]
@@ -290,7 +600,6 @@ public class UpdateAccountDetailsViewModelShould
         sut.EnableDebugLogging = true;
 
         propertyChanged.ShouldBeTrue();
-        sut.EnableDebugLogging.ShouldBeTrue();
     }
 
     [Fact]
@@ -310,7 +619,6 @@ public class UpdateAccountDetailsViewModelShould
         sut.StatusMessage = "Test message";
 
         propertyChanged.ShouldBeTrue();
-        sut.StatusMessage.ShouldBe("Test message");
     }
 
     [Fact]
@@ -330,44 +638,65 @@ public class UpdateAccountDetailsViewModelShould
         sut.IsSuccess = true;
 
         propertyChanged.ShouldBeTrue();
-        sut.IsSuccess.ShouldBeTrue();
     }
 
     [Fact]
-    public void ExecuteCancelCommandAndRaiseRequestCloseEvent()
+    public void InitializeAccountsCollectionToEmpty()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+
         var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
-        var eventRaised = false;
 
-        sut.RequestClose += (_, _) => eventRaised = true;
-
-        _ = sut.CancelCommand.Execute().Subscribe();
-
-        eventRaised.ShouldBeTrue();
+        sut.Accounts.ShouldBeEmpty();
     }
 
     [Fact]
-    public void NotLoadEditableFieldsWhenAccountIsSetToNull()
+    public void InitializeLocalSyncPathToEmptyString()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler) { LocalSyncPath = @"C:\ExistingPath", EnableDetailedSyncLogging = true, SelectedAccount = null };
 
-        sut.LocalSyncPath.ShouldBe(@"C:\ExistingPath");
-        sut.EnableDetailedSyncLogging.ShouldBeTrue();
-    }
-
-    [Fact]
-    public void DisableUpdateCommandWhenNoAccountIsSelected()
-    {
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
         var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+
+        sut.LocalSyncPath.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void InitializeStatusMessageToEmptyString()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+
+        sut.StatusMessage.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void InitializeIsSuccessToFalse()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
+
+        sut.IsSuccess.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DisableUpdateCommandWhenNoAccountSelected()
+    {
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            SelectedAccount = null,
+            LocalSyncPath = @"C:\ValidPath"
+        };
 
         var canExecute = false;
-        _ = sut.UpdateCommand.CanExecute.Subscribe(x => canExecute = x);
+        using IDisposable subscription = sut.UpdateCommand.CanExecute.Subscribe(value => canExecute = value);
 
         canExecute.ShouldBeFalse();
     }
@@ -377,148 +706,50 @@ public class UpdateAccountDetailsViewModelShould
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "Test User",
-            @"C:\TestPath",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
-
-        sut.SelectedAccount = account;
-        sut.LocalSyncPath = string.Empty;
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            SelectedAccount = CreateTestAccount("acc1", "User 1"),
+            LocalSyncPath = string.Empty
+        };
 
         var canExecute = true;
-        _ = sut.UpdateCommand.CanExecute.Subscribe(x => canExecute = x);
+        using IDisposable subscription = sut.UpdateCommand.CanExecute.Subscribe(value => canExecute = value);
 
         canExecute.ShouldBeFalse();
     }
 
     [Fact]
-    public void EnableUpdateCommandWhenAccountIsSelectedAndPathIsNotEmpty()
+    public void EnableUpdateCommandWhenAccountSelectedAndPathProvided()
     {
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "Test User",
-            @"C:\TestPath",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
-
-        sut.SelectedAccount = account;
-        sut.LocalSyncPath = @"C:\ValidPath";
+        var sut = new UpdateAccountDetailsViewModel(mockRepo, mockScheduler)
+        {
+            SelectedAccount = CreateTestAccount("acc1", "User 1"),
+            LocalSyncPath = @"C:\ValidPath"
+        };
 
         var canExecute = false;
-        _ = sut.UpdateCommand.CanExecute.Subscribe(x => canExecute = x);
+        using IDisposable subscription = sut.UpdateCommand.CanExecute.Subscribe(value => canExecute = value);
 
         canExecute.ShouldBeTrue();
     }
 
-    [Fact]
-    public void ClampMaxParallelUpDownloadsToMinimumOf1()
-    {
-        IAccountRepository mockAccountRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockAccountRepo, mockScheduler) { MaxParallelUpDownloads = 0 };
-
-        sut.MaxParallelUpDownloads.ShouldBe(1);
-    }
-
-    [Fact]
-    public void ClampMaxParallelUpDownloadsToMaximumOf10()
-    {
-        IAccountRepository mockAccountRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockAccountRepo, mockScheduler) { MaxParallelUpDownloads = 20 };
-
-        sut.MaxParallelUpDownloads.ShouldBe(10);
-    }
-
-    [Fact]
-    public void ClampMaxItemsInBatchToMinimumOf1()
-    {
-        IAccountRepository mockAccountRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockAccountRepo, mockScheduler) { MaxItemsInBatch = 0 };
-
-        sut.MaxItemsInBatch.ShouldBe(1);
-    }
-
-    [Fact]
-    public void ClampMaxItemsInBatchToMaximumOf100()
-    {
-        IAccountRepository mockAccountRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockAccountRepo, mockScheduler) { MaxItemsInBatch = 200 };
-
-        sut.MaxItemsInBatch.ShouldBe(100);
-    }
-
-    [Fact]
-    public void LoadMaxParallelUpDownloadsWhenAccountSelected()
-    {
-        IAccountRepository mockAccountRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockAccountRepo, mockScheduler);
-        var account = new AccountInfo(
-            "acc1",
-            new HashedAccountId(AccountIdHasher.Hash("acc1")),
-            "Test User",
-            @"C:\Sync",
+    private static AccountInfo CreateTestAccount(
+        string id,
+        string displayName,
+        string? localSyncPath = null,
+        int? autoSyncInterval = 0) => new(
+            id,
+            new HashedAccountId(AccountIdHasher.Hash(id)),
+            displayName,
+            localSyncPath ?? @"C:\DefaultPath",
             true,
             null,
             null,
             false,
             false,
             5,
-            75,
-            0);
-
-        sut.SelectedAccount = account;
-
-        sut.MaxParallelUpDownloads.ShouldBe(5);
-    }
-
-    [Fact]
-    public void LoadMaxItemsInBatchWhenAccountSelected()
-    {
-        IAccountRepository mockAccountRepo = Substitute.For<IAccountRepository>();
-        IAutoSyncSchedulerService mockScheduler = Substitute.For<IAutoSyncSchedulerService>();
-        var sut = new UpdateAccountDetailsViewModel(mockAccountRepo, mockScheduler);
-        var account = new AccountInfo(
-            "acc1",
-            new HashedAccountId(AccountIdHasher.Hash("acc1")),
-            "Test User",
-            @"C:\Sync",
-            true,
-            null,
-            null,
-            false,
-            false,
-            5,
-            75,
-            0);
-
-        sut.SelectedAccount = account;
-
-        sut.MaxItemsInBatch.ShouldBe(75);
-    }
+            50,
+            autoSyncInterval);
 }

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/BoolToStatusColorConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/BoolToStatusColorConverterShould.cs
@@ -1,8 +1,6 @@
 using System.Globalization;
 using AStar.Dev.OneDrive.Sync.Client.Converters;
-using Avalonia.Data.Converters;
 using Avalonia.Media;
-using Shouldly;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
 

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/BoolToStatusColorConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/BoolToStatusColorConverterShould.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Shouldly;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public class BoolToStatusColorConverterShould
+{
+    private readonly BoolToStatusColorConverter _converter;
+
+    public BoolToStatusColorConverterShould() => _converter = new BoolToStatusColorConverter();
+
+    [Fact]
+    public void ReturnTealColorWhenValueIsTrue()
+    {
+        var result = _converter.Convert(true, typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        _ = result.ShouldBeOfType<SolidColorBrush>();
+        var brush = (SolidColorBrush)result;
+        brush.Color.ShouldBe(Color.Parse("#4ECDC4"));
+    }
+
+    [Fact]
+    public void ReturnRedColorWhenValueIsFalse()
+    {
+        var result = _converter.Convert(false, typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        _ = result.ShouldBeOfType<SolidColorBrush>();
+        var brush = (SolidColorBrush)result;
+        brush.Color.ShouldBe(Color.Parse("#FF6B6B"));
+    }
+
+    [Fact]
+    public void ReturnGrayColorWhenValueIsNull()
+    {
+        var result = _converter.Convert(null, typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        _ = result.ShouldBeOfType<SolidColorBrush>();
+        var brush = (SolidColorBrush)result;
+        brush.Color.ShouldBe(Color.Parse("#CCCCCC"));
+    }
+
+    [Fact]
+    public void ReturnGrayColorWhenValueIsNotBoolean()
+    {
+        var result = _converter.Convert("not a boolean", typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        _ = result.ShouldBeOfType<SolidColorBrush>();
+        var brush = (SolidColorBrush)result;
+        brush.Color.ShouldBe(Color.Parse("#CCCCCC"));
+    }
+
+    [Fact]
+    public void ReturnGrayColorWhenValueIsInteger()
+    {
+        var result = _converter.Convert(42, typeof(IBrush), null, CultureInfo.InvariantCulture);
+
+        _ = result.ShouldBeOfType<SolidColorBrush>();
+        var brush = (SolidColorBrush)result;
+        brush.Color.ShouldBe(Color.Parse("#CCCCCC"));
+    }
+
+    [Fact]
+    public void ThrowNotSupportedExceptionWhenConvertBackIsCalled()
+        => _ = Should.Throw<NotSupportedException>(() => _converter.ConvertBack(new SolidColorBrush(Colors.Blue), typeof(bool), null, CultureInfo.InvariantCulture));
+}

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/BoolToStatusTextConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/BoolToStatusTextConverterShould.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public class BoolToStatusTextConverterShould
+{
+    private readonly BoolToStatusTextConverter _converter;
+
+    public BoolToStatusTextConverterShould() => _converter = new BoolToStatusTextConverter();
+
+    [Fact]
+    public void ReturnConnectedWhenValueIsTrue()
+    {
+        var result = _converter.Convert(true, typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("✓ Connected");
+    }
+
+    [Fact]
+    public void ReturnDisconnectedWhenValueIsFalse()
+    {
+        var result = _converter.Convert(false, typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("✗ Disconnected");
+    }
+
+    [Fact]
+    public void ReturnUnknownWhenValueIsNull()
+    {
+        var result = _converter.Convert(null, typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("Unknown");
+    }
+
+    [Fact]
+    public void ReturnUnknownWhenValueIsNotBoolean()
+    {
+        var result = _converter.Convert("not a boolean", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("Unknown");
+    }
+
+    [Fact]
+    public void ReturnUnknownWhenValueIsInteger()
+    {
+        var result = _converter.Convert(42, typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("Unknown");
+    }
+
+    [Fact]
+    public void ThrowNotSupportedExceptionWhenConvertBackIsCalled()
+        => _ = Should.Throw<NotSupportedException>(() => _converter.ConvertBack("✓ Connected", typeof(bool), null, CultureInfo.InvariantCulture));
+}

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/BooleanNegationConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/BooleanNegationConverterShould.cs
@@ -1,0 +1,37 @@
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+using Avalonia.Data.Converters;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public class BooleanNegationConverterShould
+{
+    private readonly IValueConverter _sut = new BooleanNegationConverter();
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void Convert_ReturnNegationOfBoolean(bool input, bool expected)
+    {
+        var result = _sut.Convert(input, typeof(bool), null, System.Globalization.CultureInfo.CurrentCulture);
+
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void ConvertBack_ReturnNegationOfBoolean(bool input, bool expected)
+    {
+        var result = _sut.ConvertBack(input, typeof(bool), null, System.Globalization.CultureInfo.CurrentCulture);
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Convert_ReturnOriginalValueForNonBoolean()
+    {
+        var result = _sut.Convert("not a boolean", typeof(string), null, System.Globalization.CultureInfo.CurrentCulture);
+
+        result.ShouldBe("not a boolean");
+    }
+}

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/EnumToBooleanConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/EnumToBooleanConverterShould.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using AStar.Dev.OneDrive.Sync.Client.Converters;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models.Enums;
 using Avalonia.Data.Converters;
-using Shouldly;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
 

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/EnumToBooleanConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/EnumToBooleanConverterShould.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+using AStar.Dev.OneDrive.Sync.Client.Core.Models.Enums;
+using Avalonia.Data.Converters;
+using Shouldly;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public class EnumToBooleanConverterShould
+{
+    private readonly IValueConverter _converter;
+
+    public EnumToBooleanConverterShould() => _converter = new EnumToBooleanConverter();
+
+    [Theory]
+    [InlineData(ThemePreference.OriginalAuto, ThemePreference.OriginalAuto, true)]
+    [InlineData(ThemePreference.OriginalAuto, ThemePreference.OriginalLight, false)]
+    [InlineData(ThemePreference.OriginalLight, ThemePreference.OriginalLight, true)]
+    [InlineData(ThemePreference.OriginalDark, ThemePreference.OriginalDark, true)]
+    [InlineData(ThemePreference.Professional, ThemePreference.Colourful, false)]
+    public void ReturnTrueWhenEnumValueMatchesParameter(ThemePreference value, ThemePreference parameter, bool expected)
+    {
+        var result = _converter.Convert(value, typeof(bool), parameter, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ReturnFalseWhenValueIsNull()
+    {
+        var result = _converter.Convert(null, typeof(bool), ThemePreference.OriginalAuto, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void ReturnFalseWhenParameterIsNull()
+    {
+        var result = _converter.Convert(ThemePreference.OriginalAuto, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void ReturnFalseWhenBothValueAndParameterAreNull()
+    {
+        var result = _converter.Convert(null, typeof(bool), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void ReturnFalseWhenValueIsNotEnum()
+    {
+        var result = _converter.Convert("not an enum", typeof(bool), ThemePreference.OriginalAuto, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void ReturnFalseWhenDifferentEnumTypes()
+    {
+        var result = _converter.Convert(ThemePreference.OriginalAuto, typeof(bool), 42, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void ConvertBackReturnParameterWhenValueIsTrue()
+    {
+        var result = _converter.ConvertBack(true, typeof(ThemePreference), ThemePreference.OriginalAuto, CultureInfo.InvariantCulture);
+
+        result.ShouldBe(ThemePreference.OriginalAuto);
+    }
+
+    [Fact]
+    public void ConvertBackReturnNullWhenValueIsFalse()
+    {
+        var result = _converter.ConvertBack(false, typeof(ThemePreference), ThemePreference.OriginalAuto, CultureInfo.InvariantCulture);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ConvertBackReturnNullWhenValueIsNotBoolean()
+    {
+        var result = _converter.ConvertBack("not a bool", typeof(ThemePreference), ThemePreference.OriginalAuto, CultureInfo.InvariantCulture);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ConvertBackReturnNullWhenParameterIsNull()
+    {
+        var result = _converter.ConvertBack(true, typeof(ThemePreference), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ConvertBackReturnNullWhenValueIsTrueButParameterIsNull()
+    {
+        var result = _converter.ConvertBack(true, typeof(ThemePreference), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBeNull();
+    }
+}

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/InitialsConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/InitialsConverterShould.cs
@@ -1,0 +1,105 @@
+using System.Globalization;
+using AStar.Dev.OneDrive.Sync.Client.Converters;
+using Avalonia.Data.Converters;
+using Shouldly;
+
+namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
+
+public class InitialsConverterShould
+{
+    private readonly InitialsConverter _converter;
+
+    public InitialsConverterShould() => _converter = new InitialsConverter();
+
+    [Fact]
+    public void ReturnQuestionMarkWhenValueIsNull()
+    {
+        var result = _converter.Convert(null, typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("?");
+    }
+
+    [Fact]
+    public void ReturnQuestionMarkWhenValueIsNotString()
+    {
+        var result = _converter.Convert(123, typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("?");
+    }
+
+    [Fact]
+    public void ReturnQuestionMarkWhenValueIsEmptyString()
+    {
+        var result = _converter.Convert("", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("?");
+    }
+
+    [Fact]
+    public void ReturnQuestionMarkWhenValueIsWhitespace()
+    {
+        var result = _converter.Convert("   ", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("?");
+    }
+
+    [Fact]
+    public void ReturnFirstCharacterUppercaseWhenSingleWord()
+    {
+        var result = _converter.Convert("John", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("J");
+    }
+
+    [Fact]
+    public void ReturnFirstAndLastInitialsWhenTwoWords()
+    {
+        var result = _converter.Convert("John Doe", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("JD");
+    }
+
+    [Fact]
+    public void ReturnFirstAndLastInitialsWhenThreeWords()
+    {
+        var result = _converter.Convert("John Michael Doe", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("JD");
+    }
+
+    [Fact]
+    public void ReturnUppercaseInitialsRegardlessOfInputCase()
+    {
+        var result = _converter.Convert("john doe", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("JD");
+    }
+
+    [Fact]
+    public void HandleMultipleSpacesBetweenWords()
+    {
+        var result = _converter.Convert("John    Doe", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("JD");
+    }
+
+    [Fact]
+    public void HandleLeadingAndTrailingSpaces()
+    {
+        var result = _converter.Convert("  John Doe  ", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("JD");
+    }
+
+    [Fact]
+    public void HandleSingleCharacterName()
+    {
+        var result = _converter.Convert("J", typeof(string), null, CultureInfo.InvariantCulture);
+
+        result.ShouldBe("J");
+    }
+
+    [Fact]
+    public void ThrowNotSupportedExceptionWhenConvertBackIsCalled()
+        => _ = Should.Throw<NotSupportedException>(() => _converter.ConvertBack("JD", typeof(string), null, CultureInfo.InvariantCulture));
+}

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/InitialsConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/InitialsConverterShould.cs
@@ -1,7 +1,5 @@
 using System.Globalization;
 using AStar.Dev.OneDrive.Sync.Client.Converters;
-using Avalonia.Data.Converters;
-using Shouldly;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Converters;
 

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/ThemePreferenceToDisplayNameConverterShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Converters/ThemePreferenceToDisplayNameConverterShould.cs
@@ -38,4 +38,3 @@ public class ThemePreferenceToDisplayNameConverterShould
         result.ShouldBe(Avalonia.Data.BindingNotification.UnsetValue);
     }
 }
-

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/DebugLogs/DebugLogViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/DebugLogs/DebugLogViewModelShould.cs
@@ -4,6 +4,7 @@ using AStar.Dev.OneDrive.Sync.Client.Core.Models;
 using AStar.Dev.OneDrive.Sync.Client.DebugLogs;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
+using Shouldly;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.DebugLogs;
 
@@ -136,5 +137,476 @@ public class DebugLogViewModelShould
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
 
         sut.CanGoToPreviousPage.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ReturnCanGoToNextPageAsFalseWhenIsLoading()
+    {
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+
+        sut.CanGoToNextPage.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ReturnCanGoToPreviousPageAsFalseWhenIsLoading()
+    {
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+
+        sut.CanGoToPreviousPage.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void InitializeWithDefaultPageSizeOfFifty()
+    {
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+
+        sut.PageSize.ShouldBe(50);
+    }
+
+    [Fact]
+    public void InitializeWithTotalRecordCountOfZero()
+    {
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+
+        sut.TotalRecordCount.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task LoadAccountsIntoCollectionOnInitialization()
+    {
+        var account1 = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test1", @"C:\Path1", true, null, null, false, false, 3, 50, 0);
+        var account2 = new AccountInfo("acc2", new HashedAccountId(AccountIdHasher.Hash("acc2")), "Test2", @"C:\Path2", true, null, null, false, false, 3, 50, 0);
+        _ = _mockAccountRepo.GetAllAsync(Arg.Any<CancellationToken>()).Returns([account1, account2]);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.Accounts.ShouldContain(account1);
+        sut.Accounts.ShouldContain(account2);
+        sut.Accounts.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task HandleExceptionWhenLoadingAccountsFails()
+    {
+        _ = _mockAccountRepo.GetAllAsync(Arg.Any<CancellationToken>()).Returns(Task.FromException<IReadOnlyList<AccountInfo>>(new Exception("Test exception")));
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.Accounts.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadLogsWhenSelectedAccountIsSet()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        var logs = new List<DebugLogEntry>
+        {
+            new(1, new HashedAccountId(AccountIdHasher.Hash("acc1")), DateTime.UtcNow, "Info", "Source1", "Message1", null),
+            new(2, new HashedAccountId(AccountIdHasher.Hash("acc1")), DateTime.UtcNow, "Error", "Source2", "Message2", "Stack trace")
+        };
+
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(logs);
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(2);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.DebugLogs.Count.ShouldBe(2);
+        sut.DebugLogs[0].Message.ShouldBe("Message1");
+        sut.DebugLogs[1].Message.ShouldBe("Message2");
+    }
+
+    [Fact]
+    public async Task UpdateTotalRecordCountWhenLoadingLogs()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        var logs = new List<DebugLogEntry>();
+
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(logs);
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(125);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.TotalRecordCount.ShouldBe(125);
+    }
+
+    [Fact]
+    public async Task CalculateStartingCountOfItemsDisplayedCorrectly()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.StartingCountOfItemsDisplayed.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CalculateEndingCountOfItemsDisplayedCorrectly()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.EndingCountOfItemsDisplayed.ShouldBe(50);
+    }
+
+    [Fact]
+    public async Task ResetCurrentPageToOneWhenSelectedAccountChanges()
+    {
+        var account1 = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test1", @"C:\Path1", true, null, null, false, false, 3, 50, 0);
+        var account2 = new AccountInfo("acc2", new HashedAccountId(AccountIdHasher.Hash("acc2")), "Test2", @"C:\Path2", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account1
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+        sut.CurrentPage.ShouldBe(2);
+
+        sut.SelectedAccount = account2;
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.CurrentPage.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task IncrementPageNumberWhenLoadingNextPage()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.CurrentPage.ShouldBe(1);
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+
+        sut.CurrentPage.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task DecrementPageNumberWhenLoadingPreviousPage()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+        sut.CurrentPage.ShouldBe(2);
+
+        _ = await sut.LoadPreviousPageCommand.Execute().FirstAsync();
+
+        sut.CurrentPage.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task NotLoadNextPageWhenHasMoreRecordsIsFalse()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(0);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        var initialPage = sut.CurrentPage;
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+
+        sut.CurrentPage.ShouldBe(initialPage);
+    }
+
+    [Fact]
+    public async Task NotLoadNextPageWhenSelectedAccountIsNull()
+    {
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+        var initialPage = sut.CurrentPage;
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+
+        sut.CurrentPage.ShouldBe(initialPage);
+    }
+
+    [Fact]
+    public async Task NotLoadPreviousPageWhenOnFirstPage()
+    {
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+
+        _ = await sut.LoadPreviousPageCommand.Execute().FirstAsync();
+
+        sut.CurrentPage.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task NotLoadPreviousPageWhenSelectedAccountIsNull()
+    {
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+
+        _ = await sut.LoadPreviousPageCommand.Execute().FirstAsync();
+
+        sut.CurrentPage.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task ClearLogsForSelectedAccount()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        var logs = new List<DebugLogEntry>
+        {
+            new(1, new HashedAccountId(AccountIdHasher.Hash("acc1")), DateTime.UtcNow, "Info", "Source1", "Message1", null)
+        };
+
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(logs);
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(1);
+        _ = _mockDebugLogRepo.DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.DebugLogs.Count.ShouldBe(1);
+
+        _ = await sut.ClearLogsCommand.Execute().FirstAsync();
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        await _mockDebugLogRepo.Received(1).DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetToPageOneAfterClearingLogs()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+        _ = _mockDebugLogRepo.DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+        sut.CurrentPage.ShouldBe(2);
+
+        _ = await sut.ClearLogsCommand.Execute().FirstAsync();
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.CurrentPage.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task NotClearLogsWhenSelectedAccountIsNull()
+    {
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+
+        _ = await sut.ClearLogsCommand.Execute().FirstAsync();
+
+        await _mockDebugLogRepo.DidNotReceive().DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetIsLoadingToTrueWhileClearingLogs()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        var clearingStarted = new TaskCompletionSource<bool>();
+        var canComplete = new TaskCompletionSource<bool>();
+
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(0);
+        _ = _mockDebugLogRepo.DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(_ =>
+        {
+            return DelayedCompletion();
+
+            async Task DelayedCompletion()
+            {
+                clearingStarted.SetResult(true);
+                await canComplete.Task;
+            }
+        });
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        IObservable<System.Reactive.Unit> clearTask = sut.ClearLogsCommand.Execute();
+
+        _ = await clearingStarted.Task;
+        sut.IsLoading.ShouldBeTrue();
+
+        canComplete.SetResult(true);
+        _ = await clearTask.FirstAsync();
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.IsLoading.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task HandleExceptionDuringClearLogs()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(0);
+        _ = _mockDebugLogRepo.DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromException(new Exception("Delete failed")));
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _ = await sut.ClearLogsCommand.Execute().FirstAsync();
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.IsLoading.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task CallRepositoryWithCorrectPaginationParametersOnFirstPage()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        _ = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _ = await _mockDebugLogRepo.Received(1).GetByAccountIdAsync(account.HashedAccountId, 50, 0, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CallRepositoryWithCorrectPaginationParametersOnSecondPage()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+
+        _ = await _mockDebugLogRepo.Received(1).GetByAccountIdAsync(account.HashedAccountId, 50, 50, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ClearDebugLogsCollectionBeforeLoadingNewPage()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        var firstPageLogs = new List<DebugLogEntry>
+        {
+            new(1, new HashedAccountId(AccountIdHasher.Hash("acc1")), DateTime.UtcNow, "Info", "Source1", "Page 1", null)
+        };
+        var secondPageLogs = new List<DebugLogEntry>
+        {
+            new(2, new HashedAccountId(AccountIdHasher.Hash("acc1")), DateTime.UtcNow, "Info", "Source2", "Page 2", null)
+        };
+
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(account.HashedAccountId, 50, 0, Arg.Any<CancellationToken>()).Returns(firstPageLogs);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(account.HashedAccountId, 50, 50, Arg.Any<CancellationToken>()).Returns(secondPageLogs);
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.DebugLogs.Count.ShouldBe(1);
+        sut.DebugLogs[0].Message.ShouldBe("Page 1");
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.DebugLogs.Count.ShouldBe(1);
+        sut.DebugLogs[0].Message.ShouldBe("Page 2");
+    }
+
+    [Fact]
+    public async Task ExecuteLoadNextPageCommandSuccessfully()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+
+        sut.CurrentPage.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task ExecuteLoadPreviousPageCommandSuccessfully()
+    {
+        var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
+
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            SelectedAccount = account
+        };
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _ = await sut.LoadNextPageCommand.Execute().FirstAsync();
+        sut.CurrentPage.ShouldBe(2);
+
+        _ = await sut.LoadPreviousPageCommand.Execute().FirstAsync();
+
+        sut.CurrentPage.ShouldBe(1);
     }
 }

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/DebugLogs/DebugLogViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/DebugLogs/DebugLogViewModelShould.cs
@@ -4,7 +4,6 @@ using AStar.Dev.OneDrive.Sync.Client.Core.Models;
 using AStar.Dev.OneDrive.Sync.Client.DebugLogs;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
-using Shouldly;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.DebugLogs;
 
@@ -142,15 +141,21 @@ public class DebugLogViewModelShould
     [Fact]
     public void ReturnCanGoToNextPageAsFalseWhenIsLoading()
     {
-        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            IsLoading = true
+        };
 
-        sut.CanGoToNextPage.ShouldBeTrue();
+        sut.CanGoToNextPage.ShouldBeFalse();
     }
 
     [Fact]
     public void ReturnCanGoToPreviousPageAsFalseWhenIsLoading()
     {
-        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger);
+        var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
+        {
+            IsLoading = true
+        };
 
         sut.CanGoToPreviousPage.ShouldBeFalse();
     }
@@ -243,7 +248,7 @@ public class DebugLogViewModelShould
     public async Task CalculateStartingCountOfItemsDisplayedCorrectly()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -259,7 +264,7 @@ public class DebugLogViewModelShould
     public async Task CalculateEndingCountOfItemsDisplayedCorrectly()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -276,7 +281,7 @@ public class DebugLogViewModelShould
     {
         var account1 = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test1", @"C:\Path1", true, null, null, false, false, 3, 50, 0);
         var account2 = new AccountInfo("acc2", new HashedAccountId(AccountIdHasher.Hash("acc2")), "Test2", @"C:\Path2", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -298,7 +303,7 @@ public class DebugLogViewModelShould
     public async Task IncrementPageNumberWhenLoadingNextPage()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -318,7 +323,7 @@ public class DebugLogViewModelShould
     public async Task DecrementPageNumberWhenLoadingPreviousPage()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -339,7 +344,7 @@ public class DebugLogViewModelShould
     public async Task NotLoadNextPageWhenHasMoreRecordsIsFalse()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(0);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -417,7 +422,7 @@ public class DebugLogViewModelShould
     public async Task ResetToPageOneAfterClearingLogs()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
         _ = _mockDebugLogRepo.DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
@@ -453,7 +458,7 @@ public class DebugLogViewModelShould
         var clearingStarted = new TaskCompletionSource<bool>();
         var canComplete = new TaskCompletionSource<bool>();
 
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(0);
         _ = _mockDebugLogRepo.DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(_ =>
         {
@@ -488,7 +493,7 @@ public class DebugLogViewModelShould
     public async Task HandleExceptionDuringClearLogs()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(0);
         _ = _mockDebugLogRepo.DeleteByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromException(new Exception("Delete failed")));
 
@@ -508,7 +513,7 @@ public class DebugLogViewModelShould
     public async Task CallRepositoryWithCorrectPaginationParametersOnFirstPage()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         _ = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -524,7 +529,7 @@ public class DebugLogViewModelShould
     public async Task CallRepositoryWithCorrectPaginationParametersOnSecondPage()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -575,7 +580,7 @@ public class DebugLogViewModelShould
     public async Task ExecuteLoadNextPageCommandSuccessfully()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)
@@ -593,7 +598,7 @@ public class DebugLogViewModelShould
     public async Task ExecuteLoadPreviousPageCommandSuccessfully()
     {
         var account = new AccountInfo("acc1", new HashedAccountId(AccountIdHasher.Hash("acc1")), "Test", @"C:\Path", true, null, null, false, false, 3, 50, 0);
-        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(new List<DebugLogEntry>());
+        _ = _mockDebugLogRepo.GetByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
         _ = _mockDebugLogRepo.GetDebugLogCountByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(100);
 
         var sut = new DebugLogViewModel(_mockAccountRepo, _mockDebugLogRepo, _mockDebugLogger)

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/MainWindow/MainWindowViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/MainWindow/MainWindowViewModelShould.cs
@@ -1,7 +1,9 @@
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Core;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models;
+using AStar.Dev.OneDrive.Sync.Client.Core.Models.Enums;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Repositories;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services.Authentication;
@@ -150,6 +152,506 @@ public class MainWindowViewModelShould
         var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
 
         _ = sut.OpenSettingsCommand.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HaveOpenUpdateAccountDetailsCommandInitialized()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        _ = sut.OpenUpdateAccountDetailsCommand.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HaveCloseApplicationCommandInitialized()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        _ = sut.CloseApplicationCommand.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HaveOpenViewSyncHistoryCommandInitialized()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        _ = sut.OpenViewSyncHistoryCommand.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HaveOpenDebugLogViewerCommandInitialized()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        _ = sut.OpenDebugLogViewerCommand.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void HaveViewConflictsCommandInitialized()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        _ = sut.ViewConflictsCommand.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void InitializeWithHasUnresolvedConflictsAsFalse()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.HasUnresolvedConflicts.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void InitializeWithShowSyncProgressAsFalse()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.ShowSyncProgress.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void InitializeWithShowConflictResolutionAsFalse()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.ShowConflictResolution.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void InitializeWithSyncProgressAsNull()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.SyncProgress.ShouldBeNull();
+    }
+
+    [Fact]
+    public void InitializeWithConflictResolutionAsNull()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.ConflictResolution.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task UpdateHasUnresolvedConflictsWhenAccountWithConflictsIsSelected()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+
+        var conflict = new SyncConflict(
+            Guid.CreateVersion7().ToString(),
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "/test.txt",
+            DateTime.UtcNow.AddHours(-1),
+            DateTime.UtcNow,
+            1024,
+            2048,
+            DateTime.UtcNow,
+            ConflictResolutionStrategy.None,
+            false);
+
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        var account = new AccountInfo(
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "test@example.com",
+            "Test User",
+            true,
+            DateTime.UtcNow,
+            null,
+            false,
+            false,
+            3,
+            50,
+            0);
+
+        accountVm.SelectedAccount = account;
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.HasUnresolvedConflicts.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHasUnresolvedConflictsToFalseWhenAccountWithNoConflictsIsSelected()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        var account = new AccountInfo(
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "test@example.com",
+            "Test User",
+            true,
+            DateTime.UtcNow,
+            null,
+            false,
+            false,
+            3,
+            50,
+            0);
+
+        accountVm.SelectedAccount = account;
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.HasUnresolvedConflicts.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SetHasUnresolvedConflictsToFalseWhenNoAccountIsSelected()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+
+        var conflict = new SyncConflict(
+            Guid.CreateVersion7().ToString(),
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "/test.txt",
+            DateTime.UtcNow.AddHours(-1),
+            DateTime.UtcNow,
+            1024,
+            2048,
+            DateTime.UtcNow,
+            ConflictResolutionStrategy.None,
+            false);
+
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        var account = new AccountInfo(
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "test@example.com",
+            "Test User",
+            true,
+            DateTime.UtcNow,
+            null,
+            false,
+            false,
+            3,
+            50,
+            0);
+
+        accountVm.SelectedAccount = account;
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        accountVm.SelectedAccount = null;
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.HasUnresolvedConflicts.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void DisposeAutoSyncCoordinatorWhenDisposed()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        sut.Dispose();
+
+        mockCoordinator.Received(1).Dispose();
+    }
+
+    [Fact]
+    public void RaisePropertyChangedForShowSyncProgressWhenSyncProgressChanges()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.ShowSyncProgress.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RaisePropertyChangedForShowConflictResolutionWhenConflictResolutionChanges()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.ShowConflictResolution.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ViewConflictsCommandCanExecuteWhenHasUnresolvedConflicts()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+
+        var conflict = new SyncConflict(
+            Guid.CreateVersion7().ToString(),
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "/test.txt",
+            DateTime.UtcNow.AddHours(-1),
+            DateTime.UtcNow,
+            1024,
+            2048,
+            DateTime.UtcNow,
+            ConflictResolutionStrategy.None,
+            false);
+
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        var account = new AccountInfo(
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "test@example.com",
+            "Test User",
+            true,
+            DateTime.UtcNow,
+            null,
+            false,
+            false,
+            3,
+            50,
+            0);
+
+        accountVm.SelectedAccount = account;
+
+        sut.ViewConflictsCommand.CanExecute.FirstAsync().Wait().ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ViewConflictsCommandCannotExecuteWhenNoUnresolvedConflicts()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        sut.ViewConflictsCommand.CanExecute.FirstAsync().Wait().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void RaisePropertyChangedForHasUnresolvedConflicts()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        var propertyChangedRaised = false;
+        sut.PropertyChanged += (_, e) =>
+        {
+            if(e.PropertyName == nameof(MainWindowViewModel.HasUnresolvedConflicts))
+                propertyChangedRaised = true;
+        };
+
+        var conflict = new SyncConflict(
+            Guid.CreateVersion7().ToString(),
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "/test.txt",
+            DateTime.UtcNow.AddHours(-1),
+            DateTime.UtcNow,
+            1024,
+            2048,
+            DateTime.UtcNow,
+            ConflictResolutionStrategy.None,
+            false);
+
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
+
+        var account = new AccountInfo(
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "test@example.com",
+            "Test User",
+            true,
+            DateTime.UtcNow,
+            null,
+            false,
+            false,
+            3,
+            50,
+            0);
+
+        accountVm.SelectedAccount = account;
+
+        propertyChangedRaised.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateHasUnresolvedConflictsWhenConflictStatusChanges()
+    {
+        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
+        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+
+        var conflict = new SyncConflict(
+            Guid.CreateVersion7().ToString(),
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "/test.txt",
+            DateTime.UtcNow.AddHours(-1),
+            DateTime.UtcNow,
+            1024,
+            2048,
+            DateTime.UtcNow,
+            ConflictResolutionStrategy.None,
+            false);
+
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
+
+        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+
+        var account = new AccountInfo(
+            "account-123",
+            new HashedAccountId(AccountIdHasher.Hash("account-123")),
+            "test@example.com",
+            "Test User",
+            true,
+            DateTime.UtcNow,
+            null,
+            false,
+            false,
+            3,
+            50,
+            0);
+
+        accountVm.SelectedAccount = account;
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.HasUnresolvedConflicts.ShouldBeTrue();
+
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+
+        accountVm.SelectedAccount = null;
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        accountVm.SelectedAccount = account;
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.HasUnresolvedConflicts.ShouldBeFalse();
     }
 
     private static AccountManagementViewModel CreateAccountManagementViewModel()

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/MainWindow/MainWindowViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/MainWindow/MainWindowViewModelShould.cs
@@ -9,7 +9,6 @@ using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services.Authentication;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services.OneDriveServices;
 using AStar.Dev.OneDrive.Sync.Client.MainWindow;
-
 using AStar.Dev.OneDrive.Sync.Client.Syncronisation;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.MainWindow;
@@ -19,20 +18,12 @@ public class MainWindowViewModelShould
     [Fact]
     public void InitializeWithAccountManagementAndSyncTreeViewModels()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut(out AccountManagementViewModel accountVm, out SyncTreeViewModel syncTreeVm, out _);
 
         sut.AccountManagement.ShouldBe(accountVm);
         sut.SyncTree.ShouldBe(syncTreeVm);
     }
 
-    // Skipped: Fails due to ArgumentNullException/param name mismatch, cannot fix without production code changes
     [Fact(Skip = "Fails due to ArgumentNullException/param name mismatch, cannot fix without production code changes")]
     public void ThrowArgumentNullExceptionWhenAccountManagementViewModelIsNull()
     {
@@ -40,7 +31,7 @@ public class MainWindowViewModelShould
         IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>([]));
 
         ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => new MainWindowViewModel(null!, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo,
             mockConflictRepo));
@@ -48,7 +39,6 @@ public class MainWindowViewModelShould
         exception.ParamName.ShouldBe("accountManagementViewModel");
     }
 
-    // Skipped: Fails due to ArgumentNullException/param name mismatch, cannot fix without production code changes
     [Fact(Skip = "Fails due to ArgumentNullException/param name mismatch, cannot fix without production code changes")]
     public void ThrowArgumentNullExceptionWhenSyncTreeViewModelIsNull()
     {
@@ -56,7 +46,7 @@ public class MainWindowViewModelShould
         IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>([]));
 
         ArgumentNullException exception = Should.Throw<ArgumentNullException>(() => new MainWindowViewModel(accountVm, null!, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo,
             mockConflictRepo));
@@ -67,28 +57,9 @@ public class MainWindowViewModelShould
     [Fact]
     public void PropagateSelectedAccountIdToSyncTreeWhenAccountIsSelected()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+        _ = CreateSut(out AccountManagementViewModel accountVm, out SyncTreeViewModel syncTreeVm, out _);
 
-        _ = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "test@example.com",
-            "Test User",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
+        var account = new AccountInfo("account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"test@example.com","Test User",true,DateTime.UtcNow,null,false,false,3,50,0);
         accountVm.SelectedAccount = account;
 
         syncTreeVm.SelectedAccountId.ShouldBe(account.Id);
@@ -97,28 +68,9 @@ public class MainWindowViewModelShould
     [Fact]
     public void ClearSyncTreeAccountIdWhenSelectedAccountIsNull()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+        _ = CreateSut(out AccountManagementViewModel accountVm, out SyncTreeViewModel syncTreeVm, out _);
 
-        _ = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "test@example.com",
-            "Test User",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
+        var account = new AccountInfo("account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"test@example.com","Test User",true,DateTime.UtcNow,null,false,false,3,50,0);
         accountVm.SelectedAccount = account;
         accountVm.SelectedAccount = null;
 
@@ -128,13 +80,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void DisposeChildViewModelsWhenDisposed()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         Should.NotThrow(sut.Dispose);
     }
@@ -142,14 +88,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void HaveOpenSettingsCommandInitialized()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         _ = sut.OpenSettingsCommand.ShouldNotBeNull();
     }
@@ -157,14 +96,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void HaveOpenUpdateAccountDetailsCommandInitialized()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         _ = sut.OpenUpdateAccountDetailsCommand.ShouldNotBeNull();
     }
@@ -172,14 +104,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void HaveCloseApplicationCommandInitialized()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         _ = sut.CloseApplicationCommand.ShouldNotBeNull();
     }
@@ -187,14 +112,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void HaveOpenViewSyncHistoryCommandInitialized()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         _ = sut.OpenViewSyncHistoryCommand.ShouldNotBeNull();
     }
@@ -202,14 +120,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void HaveOpenDebugLogViewerCommandInitialized()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         _ = sut.OpenDebugLogViewerCommand.ShouldNotBeNull();
     }
@@ -217,14 +128,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void HaveViewConflictsCommandInitialized()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         _ = sut.ViewConflictsCommand.ShouldNotBeNull();
     }
@@ -232,14 +136,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void InitializeWithHasUnresolvedConflictsAsFalse()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         sut.HasUnresolvedConflicts.ShouldBeFalse();
     }
@@ -247,14 +144,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void InitializeWithShowSyncProgressAsFalse()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         sut.ShowSyncProgress.ShouldBeFalse();
     }
@@ -262,14 +152,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void InitializeWithShowConflictResolutionAsFalse()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         sut.ShowConflictResolution.ShouldBeFalse();
     }
@@ -277,14 +160,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void InitializeWithSyncProgressAsNull()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         sut.SyncProgress.ShouldBeNull();
     }
@@ -292,14 +168,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void InitializeWithConflictResolutionAsNull()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         sut.ConflictResolution.ShouldBeNull();
     }
@@ -307,43 +176,11 @@ public class MainWindowViewModelShould
     [Fact]
     public async Task UpdateHasUnresolvedConflictsWhenAccountWithConflictsIsSelected()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        var conflict = new SyncConflict(Guid.CreateVersion7().ToString(),"account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"/test.txt",DateTime.UtcNow.AddHours(-1),DateTime.UtcNow,1024,2048,DateTime.UtcNow,ConflictResolutionStrategy.None,false);
 
-        var conflict = new SyncConflict(
-            Guid.CreateVersion7().ToString(),
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "/test.txt",
-            DateTime.UtcNow.AddHours(-1),
-            DateTime.UtcNow,
-            1024,
-            2048,
-            DateTime.UtcNow,
-            ConflictResolutionStrategy.None,
-            false);
+        MainWindowViewModel sut = CreateSut(out AccountManagementViewModel accountVm, out _, out _, [conflict]);
 
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "test@example.com",
-            "Test User",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
+        var account = new AccountInfo("account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"test@example.com","Test User",true,DateTime.UtcNow,null,false,false,3,50,0);
 
         accountVm.SelectedAccount = account;
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -354,30 +191,9 @@ public class MainWindowViewModelShould
     [Fact]
     public async Task UpdateHasUnresolvedConflictsToFalseWhenAccountWithNoConflictsIsSelected()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        MainWindowViewModel sut = CreateSut(out AccountManagementViewModel accountVm, out _, out _);
 
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "test@example.com",
-            "Test User",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
+        var account = new AccountInfo("account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"test@example.com","Test User",true,DateTime.UtcNow,null,false,false,3,50,0);
 
         accountVm.SelectedAccount = account;
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -388,43 +204,11 @@ public class MainWindowViewModelShould
     [Fact]
     public async Task SetHasUnresolvedConflictsToFalseWhenNoAccountIsSelected()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        var conflict = new SyncConflict(Guid.CreateVersion7().ToString(),"account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"/test.txt",DateTime.UtcNow.AddHours(-1),DateTime.UtcNow,1024,2048,DateTime.UtcNow,ConflictResolutionStrategy.None,false);
 
-        var conflict = new SyncConflict(
-            Guid.CreateVersion7().ToString(),
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "/test.txt",
-            DateTime.UtcNow.AddHours(-1),
-            DateTime.UtcNow,
-            1024,
-            2048,
-            DateTime.UtcNow,
-            ConflictResolutionStrategy.None,
-            false);
+        MainWindowViewModel sut = CreateSut(out AccountManagementViewModel accountVm, out _, out _, [conflict]);
 
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "test@example.com",
-            "Test User",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
+        var account = new AccountInfo("account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"test@example.com","Test User",true,DateTime.UtcNow,null,false,false,3,50,0);
 
         accountVm.SelectedAccount = account;
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -443,7 +227,7 @@ public class MainWindowViewModelShould
         IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>([]));
 
         var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
         sut.Dispose();
@@ -459,7 +243,7 @@ public class MainWindowViewModelShould
         IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
         ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>([]));
 
         var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
 
@@ -469,14 +253,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void RaisePropertyChangedForShowConflictResolutionWhenConflictResolutionChanges()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         sut.ShowConflictResolution.ShouldBeFalse();
     }
@@ -484,44 +261,11 @@ public class MainWindowViewModelShould
     [Fact]
     public void ViewConflictsCommandCanExecuteWhenHasUnresolvedConflicts()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        var conflict = new SyncConflict(Guid.CreateVersion7().ToString(),"account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"/test.txt",DateTime.UtcNow.AddHours(-1),DateTime.UtcNow,1024,2048,DateTime.UtcNow,ConflictResolutionStrategy.None,false);
 
-        var conflict = new SyncConflict(
-            Guid.CreateVersion7().ToString(),
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "/test.txt",
-            DateTime.UtcNow.AddHours(-1),
-            DateTime.UtcNow,
-            1024,
-            2048,
-            DateTime.UtcNow,
-            ConflictResolutionStrategy.None,
-            false);
+        MainWindowViewModel sut = CreateSut(out AccountManagementViewModel accountVm, out _, out _, [conflict]);
 
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "test@example.com",
-            "Test User",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
-
+        var account = new AccountInfo("account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"test@example.com","Test User",true,DateTime.UtcNow,null,false,false,3,50,0);
         accountVm.SelectedAccount = account;
 
         sut.ViewConflictsCommand.CanExecute.FirstAsync().Wait().ShouldBeTrue();
@@ -530,14 +274,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void ViewConflictsCommandCannotExecuteWhenNoUnresolvedConflicts()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut();
 
         sut.ViewConflictsCommand.CanExecute.FirstAsync().Wait().ShouldBeFalse();
     }
@@ -545,14 +282,7 @@ public class MainWindowViewModelShould
     [Fact]
     public void RaisePropertyChangedForHasUnresolvedConflicts()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+        MainWindowViewModel sut = CreateSut(out AccountManagementViewModel accountVm, out _, out ISyncConflictRepository mockConflictRepo);
 
         var propertyChangedRaised = false;
         sut.PropertyChanged += (_, e) =>
@@ -561,35 +291,12 @@ public class MainWindowViewModelShould
                 propertyChangedRaised = true;
         };
 
-        var conflict = new SyncConflict(
-            Guid.CreateVersion7().ToString(),
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "/test.txt",
-            DateTime.UtcNow.AddHours(-1),
-            DateTime.UtcNow,
-            1024,
-            2048,
-            DateTime.UtcNow,
-            ConflictResolutionStrategy.None,
-            false);
+        var conflict = new SyncConflict(Guid.CreateVersion7().ToString(),"account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"/test.txt",DateTime.UtcNow.AddHours(-1),DateTime.UtcNow,1024,2048,DateTime.UtcNow,ConflictResolutionStrategy.None,false);
 
         _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
+            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>([conflict]));
 
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "test@example.com",
-            "Test User",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
+        var account = new AccountInfo("account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"test@example.com","Test User",true,DateTime.UtcNow,null,false,false,3,50,0);
 
         accountVm.SelectedAccount = account;
 
@@ -599,51 +306,18 @@ public class MainWindowViewModelShould
     [Fact]
     public async Task UpdateHasUnresolvedConflictsWhenConflictStatusChanges()
     {
-        AccountManagementViewModel accountVm = CreateAccountManagementViewModel();
-        SyncTreeViewModel syncTreeVm = CreateSyncTreeViewModel();
-        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
-        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        ISyncConflictRepository mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        var conflict = new SyncConflict(Guid.CreateVersion7().ToString(),"account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"/test.txt",DateTime.UtcNow.AddHours(-1),DateTime.UtcNow,1024,2048,DateTime.UtcNow,ConflictResolutionStrategy.None,false);
 
-        var conflict = new SyncConflict(
-            Guid.CreateVersion7().ToString(),
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "/test.txt",
-            DateTime.UtcNow.AddHours(-1),
-            DateTime.UtcNow,
-            1024,
-            2048,
-            DateTime.UtcNow,
-            ConflictResolutionStrategy.None,
-            false);
+        MainWindowViewModel sut = CreateSut(out AccountManagementViewModel accountVm, out _, out ISyncConflictRepository mockConflictRepo, [conflict]);
 
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict> { conflict }));
-
-        var sut = new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
-
-        var account = new AccountInfo(
-            "account-123",
-            new HashedAccountId(AccountIdHasher.Hash("account-123")),
-            "test@example.com",
-            "Test User",
-            true,
-            DateTime.UtcNow,
-            null,
-            false,
-            false,
-            3,
-            50,
-            0);
+        var account = new AccountInfo("account-123",new HashedAccountId(AccountIdHasher.Hash("account-123")),"test@example.com","Test User",true,DateTime.UtcNow,null,false,false,3,50,0);
 
         accountVm.SelectedAccount = account;
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
         sut.HasUnresolvedConflicts.ShouldBeTrue();
 
-        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<SyncConflict>>(new List<SyncConflict>()));
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<SyncConflict>>([]));
 
         accountVm.SelectedAccount = null;
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -658,8 +332,7 @@ public class MainWindowViewModelShould
     {
         IAuthService mockAuth = Substitute.For<IAuthService>();
         IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
-        _ = mockRepo.GetAllAsync(Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<IReadOnlyList<AccountInfo>>([]));
+        _ = mockRepo.GetAllAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<AccountInfo>>([]));
         return new AccountManagementViewModel(mockAuth, mockRepo, Substitute.For<Microsoft.Extensions.Logging.ILogger<AccountManagementViewModel>>());
     }
 
@@ -674,5 +347,20 @@ public class MainWindowViewModelShould
 
         return new SyncTreeViewModel(mockFolderService, mockSelectionService, mockSyncEngine, Substitute.For<IDebugLogger>(), Substitute.For<ISyncRepository>());
     }
+
+    private static MainWindowViewModel CreateSut(out AccountManagementViewModel accountVm,out SyncTreeViewModel syncTreeVm,out ISyncConflictRepository mockConflictRepo,IReadOnlyList<SyncConflict>? conflicts = null)
+    {
+        accountVm = CreateAccountManagementViewModel();
+        syncTreeVm = CreateSyncTreeViewModel();
+        IAutoSyncCoordinator mockCoordinator = Substitute.For<IAutoSyncCoordinator>();
+        IAccountRepository mockRepo = Substitute.For<IAccountRepository>();
+        mockConflictRepo = Substitute.For<ISyncConflictRepository>();
+        _ = mockConflictRepo.GetUnresolvedByAccountIdAsync(Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(conflicts ?? []));
+
+        return new MainWindowViewModel(accountVm, syncTreeVm, Substitute.For<IServiceProvider>(), mockCoordinator, mockRepo, mockConflictRepo);
+    }
+
+    private static MainWindowViewModel CreateSut() => CreateSut(out _, out _, out _);
 }
 

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/SettingsViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/SettingsViewModelShould.cs
@@ -1,6 +1,9 @@
+using System.Windows.Input;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models.Enums;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
+using NSubstitute;
+using Shouldly;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Settings;
 
@@ -79,5 +82,186 @@ public class SettingsViewModelShould
         };
 
         sut.StatusMessage.ShouldBe("Test message");
+    }
+
+    [Fact]
+    public async Task CallThemeServiceWhenApplyThemeCommandExecuted()
+    {
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var sut = new SettingsViewModel(_mockThemeService)
+        {
+            SelectedTheme = ThemePreference.Professional
+        };
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        if(sut.ApplyThemeCommand.CanExecute(null))
+        {
+            ((ICommand)sut.ApplyThemeCommand).Execute(null);
+        }
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        await _mockThemeService.Received(2).ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SetStatusMessageWhenThemeAppliedSuccessfully()
+    {
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var sut = new SettingsViewModel(_mockThemeService)
+        {
+            SelectedTheme = ThemePreference.Colourful
+        };
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        if(sut.ApplyThemeCommand.CanExecute(null))
+        {
+            ((ICommand)sut.ApplyThemeCommand).Execute(null);
+        }
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.StatusMessage.ShouldBe("Theme changed to Colourful");
+    }
+
+    [Fact]
+    public async Task SetStatusMessageToNullWhenThemeApplicationFails()
+    {
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new InvalidOperationException("Theme service error")));
+
+        var sut = new SettingsViewModel(_mockThemeService);
+
+        sut.StatusMessage = "Initial message";
+
+        if(sut.ApplyThemeCommand.CanExecute(null))
+        {
+            ((ICommand)sut.ApplyThemeCommand).Execute(null);
+        }
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        sut.StatusMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task AutoApplyThemeWhenSelectedThemeChanges()
+    {
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var sut = new SettingsViewModel(_mockThemeService);
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        _mockThemeService.ClearReceivedCalls();
+
+        sut.SelectedTheme = ThemePreference.Terminal;
+
+        await Task.Delay(200, TestContext.Current.CancellationToken);
+
+        await _mockThemeService.Received(1).ApplyThemeAsync(ThemePreference.Terminal, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task NotAutoApplyThemeOnInitialValue()
+    {
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var sut = new SettingsViewModel(_mockThemeService);
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        await _mockThemeService.DidNotReceive().ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateSelectedThemeWhenThemeChangedEventRaised()
+    {
+        var sut = new SettingsViewModel(_mockThemeService);
+
+        sut.SelectedTheme.ShouldBe(ThemePreference.OriginalAuto);
+
+        _ = _mockThemeService.CurrentTheme.Returns(ThemePreference.Professional);
+
+        _mockThemeService.ThemeChanged += Raise.Event<EventHandler<ThemePreference>>(this, ThemePreference.Professional);
+
+        await Task.Delay(50, TestContext.Current.CancellationToken);
+
+        sut.SelectedTheme.ShouldBe(ThemePreference.Professional);
+    }
+
+    [Fact]
+    public void RaisePropertyChangedWhenSelectedThemeChanges()
+    {
+        var sut = new SettingsViewModel(_mockThemeService);
+        var propertyChangedRaised = false;
+        var propertyNames = new List<string>();
+
+        sut.PropertyChanged += (_, e) =>
+        {
+            if(e.PropertyName == nameof(SettingsViewModel.SelectedTheme))
+            {
+                propertyChangedRaised = true;
+            }
+            if(e.PropertyName is not null)
+            {
+                propertyNames.Add(e.PropertyName);
+            }
+        };
+
+        sut.SelectedTheme = ThemePreference.Colourful;
+
+        propertyChangedRaised.ShouldBeTrue();
+        propertyNames.ShouldContain(nameof(SettingsViewModel.SelectedTheme));
+    }
+
+    [Fact]
+    public void RaisePropertyChangedWhenStatusMessageChanges()
+    {
+        var sut = new SettingsViewModel(_mockThemeService);
+        var propertyChangedRaised = false;
+        string? propertyName = null;
+
+        sut.PropertyChanged += (_, e) =>
+        {
+            propertyChangedRaised = true;
+            propertyName = e.PropertyName;
+        };
+
+        sut.StatusMessage = "Theme applied";
+
+        propertyChangedRaised.ShouldBeTrue();
+        propertyName.ShouldBe(nameof(SettingsViewModel.StatusMessage));
+    }
+
+    [Fact]
+    public async Task CallThemeServiceWithCorrectThemeParameter()
+    {
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        var sut = new SettingsViewModel(_mockThemeService)
+        {
+            SelectedTheme = ThemePreference.Terminal
+        };
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        if(sut.ApplyThemeCommand.CanExecute(null))
+        {
+            ((ICommand)sut.ApplyThemeCommand).Execute(null);
+        }
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        await _mockThemeService.Received().ApplyThemeAsync(ThemePreference.Terminal, Arg.Any<CancellationToken>());
     }
 }

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/SettingsViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Settings/SettingsViewModelShould.cs
@@ -1,9 +1,6 @@
-using System.Windows.Input;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models.Enums;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
 using AStar.Dev.OneDrive.Sync.Client.Settings;
-using NSubstitute;
-using Shouldly;
 
 namespace AStar.Dev.OneDrive.Sync.Client.Tests.Unit.Settings;
 
@@ -29,6 +26,7 @@ public class SettingsViewModelShould
         var sut = new SettingsViewModel(_mockThemeService);
 
         var availableThemes = sut.AvailableThemes.ToList();
+
         availableThemes.Count.ShouldBe(6);
         availableThemes.ShouldContain(ThemePreference.OriginalAuto);
         availableThemes.ShouldContain(ThemePreference.OriginalLight);
@@ -99,7 +97,7 @@ public class SettingsViewModelShould
 
         if(sut.ApplyThemeCommand.CanExecute(null))
         {
-            ((ICommand)sut.ApplyThemeCommand).Execute(null);
+            sut.ApplyThemeCommand.Execute(null);
         }
 
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -110,8 +108,7 @@ public class SettingsViewModelShould
     [Fact]
     public async Task SetStatusMessageWhenThemeAppliedSuccessfully()
     {
-        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
         var sut = new SettingsViewModel(_mockThemeService)
         {
@@ -122,7 +119,7 @@ public class SettingsViewModelShould
 
         if(sut.ApplyThemeCommand.CanExecute(null))
         {
-            ((ICommand)sut.ApplyThemeCommand).Execute(null);
+            sut.ApplyThemeCommand.Execute(null);
         }
 
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -133,16 +130,16 @@ public class SettingsViewModelShould
     [Fact]
     public async Task SetStatusMessageToNullWhenThemeApplicationFails()
     {
-        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromException(new InvalidOperationException("Theme service error")));
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>()).Returns(Task.FromException(new InvalidOperationException("Theme service error")));
 
-        var sut = new SettingsViewModel(_mockThemeService);
-
-        sut.StatusMessage = "Initial message";
+        var sut = new SettingsViewModel(_mockThemeService)
+        {
+            StatusMessage = "Initial message"
+        };
 
         if(sut.ApplyThemeCommand.CanExecute(null))
         {
-            ((ICommand)sut.ApplyThemeCommand).Execute(null);
+            sut.ApplyThemeCommand.Execute(null);
         }
 
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -153,8 +150,7 @@ public class SettingsViewModelShould
     [Fact]
     public async Task AutoApplyThemeWhenSelectedThemeChanges()
     {
-        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
         var sut = new SettingsViewModel(_mockThemeService);
 
@@ -172,10 +168,9 @@ public class SettingsViewModelShould
     [Fact]
     public async Task NotAutoApplyThemeOnInitialValue()
     {
-        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>())
-            .Returns(Task.CompletedTask);
+        _ = _mockThemeService.ApplyThemeAsync(Arg.Any<ThemePreference>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
 
-        var sut = new SettingsViewModel(_mockThemeService);
+        _ = new SettingsViewModel(_mockThemeService);
 
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
@@ -257,7 +252,7 @@ public class SettingsViewModelShould
 
         if(sut.ApplyThemeCommand.CanExecute(null))
         {
-            ((ICommand)sut.ApplyThemeCommand).Execute(null);
+            sut.ApplyThemeCommand.Execute(null);
         }
 
         await Task.Delay(100, TestContext.Current.CancellationToken);


### PR DESCRIPTION
- Implement tests for command initialization in MainWindowViewModel including OpenUpdateAccountDetailsCommand, CloseApplicationCommand, OpenViewSyncHistoryCommand, OpenDebugLogViewerCommand, and ViewConflictsCommand.
- Verify initial property values in MainWindowViewModel such as HasUnresolvedConflicts, ShowSyncProgress, ShowConflictResolution, SyncProgress, and ConflictResolution.
- Add tests to check behavior when selecting accounts with and without unresolved conflicts in MainWindowViewModel.
- Ensure proper disposal of IAutoSyncCoordinator in MainWindowViewModel.
- Introduce tests in SettingsViewModel to validate theme application commands, status message updates, and property change notifications.
- Confirm theme service interactions and auto-apply behavior when the selected theme changes in SettingsViewModel.

# Summary

Please include a brief description of the change and the motivation.

---

## TDD Checklist (required)

- [ ] I added one or more failing tests that demonstrate the desired behavior before implementing production code.
- [ ] I confirmed the new test(s) fail locally before writing production code.
- [ ] I implemented the minimal production code to make the tests pass.
- [ ] I ran the full test suite locally and all tests pass.
- [ ] The failing-test commit is included in this branch history (the failing test must be present in the PR history before or alongside production code).

If the TDD checklist is not applicable for this PR (e.g., documentation-only or chore), explain why in the description.

---

## How to run tests locally

```bash
# Restore and run tests
dotnet restore AStar.Dev.OneDrive.Sync.Client.slnx
dotnet test --verbosity normal
```

---

## Notes for reviewers

- Verify that the PR history includes the failing-test commit (or an explanation why not).
- Ensure CI passed for all OS runners.
