### PR TITLE
Refactor authentication handling in AccountManagementViewModel to use Result type for better error management

### DIFF
--- a/docs/install-net10-on-linux.md
+++ b/docs/install-net10-on-linux.md
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect Ubuntu base codename from Mint
+UBUNTU_CODENAME="${UBUNTU_CODENAME:-}"
+if [[ -z "$UBUNTU_CODENAME" && -f /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  source /etc/os-release
+  UBUNTU_CODENAME="${UBUNTU_CODENAME:-}"
+fi
+
+if [[ -z "$UBUNTU_CODENAME" ]]; then
+  echo "Could not detect Ubuntu base codename. Aborting."
+  exit 1
+fi
+
+case "$UBUNTU_CODENAME" in
+  jammy) UBUNTU_VERSION="22.04" ;; # Mint 21.x
+  noble) UBUNTU_VERSION="24.04" ;; # Mint 22.x
+  *)
+    echo "Unsupported Ubuntu base codename: $UBUNTU_CODENAME"
+    echo "This script supports Mint 21.x (jammy) and 22.x (noble)."
+    exit 1
+    ;;
+esac
+
+echo "Detected Ubuntu base: $UBUNTU_CODENAME ($UBUNTU_VERSION)"
+
+sudo apt-get update
+sudo apt-get install -y wget
+
+wget "https://packages.microsoft.com/config/ubuntu/${UBUNTU_VERSION}/packages-microsoft-prod.deb" -O /tmp/packages-microsoft-prod.deb
+sudo dpkg -i /tmp/packages-microsoft-prod.deb
+rm -f /tmp/packages-microsoft-prod.deb
+
+sudo apt-get update
+sudo apt-get install -y dotnet-sdk-10.0
+
+dotnet --info
+dotnet --list-sdks

--- a/plans/todo.md
+++ b/plans/todo.md
@@ -3,3 +3,6 @@
 ## Done
 
 - Align sync progress reporter delegate to include `HashedAccountId` and update call sites/tests.
+- Refactor `IAuthService` and `FolderTreeService` to use functional `Result` and `Option` patterns.
+- Resolve `Unit` type ambiguity in presentation and test layers.
+- Update UI and test suites to align with functional architectural shifts.

--- a/src/nuget-packages/AStar.Dev.Functional.Extensions/ConvenienceResultExtensions.cs
+++ b/src/nuget-packages/AStar.Dev.Functional.Extensions/ConvenienceResultExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+
+namespace AStar.Dev.Functional.Extensions;
+
+/// <summary>
+///     A set of small convenience extensions to make consuming Result{T, Exception}
+///     values in view-models and tests a bit easier.
+/// </summary>
+public static class ConvenienceResultExtensions
+{
+    /// <summary>
+    ///     Returns the contained value or throws the captured exception.
+    /// </summary>
+    public static T GetOrThrow<T>(this Result<T, Exception> result) => result switch
+    {
+        Result<T, Exception>.Ok ok => ok.Value,
+        Result<T, Exception>.Error err => throw err.Reason,
+        _ => throw new InvalidOperationException("Unrecognized Result variant")
+    };
+
+    /// <summary>
+    ///     Awaits a task returning a Result and returns the value or throws the captured exception.
+    /// </summary>
+    public static async Task<T> GetOrThrowAsync<T>(this Task<Result<T, Exception>> resultTask) => (await resultTask.ConfigureAwait(false)).GetOrThrow();
+
+    /// <summary>
+    ///     Returns a short, UI-friendly error message for the Result. Empty string for success.
+    /// </summary>
+    public static string ToErrorMessage<T>(this Result<T, Exception> result) => result is Result<T, Exception>.Error err ? err.Reason?.Message ?? string.Empty : string.Empty;
+}

--- a/test/AStar.Dev.OneDrive.Sync.Client.Infrastructure.Tests.Unit/Services/OneDriveServices/FolderTreeServiceIntegrationShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Infrastructure.Tests.Unit/Services/OneDriveServices/FolderTreeServiceIntegrationShould.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services.Authentication;
@@ -42,7 +43,8 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = (await authService.LoginAsync(TestContext.Current.CancellationToken))
+            .Match(success => success, error => throw new InvalidOperationException($"Auth failed: {error.Message}"));
 
         if(!loginResult.Success || string.IsNullOrWhiteSpace(loginResult.HashedAccountId.Value))
             throw new InvalidOperationException("Failed to authenticate with OneDrive");
@@ -65,7 +67,8 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = (await authService.LoginAsync(TestContext.Current.CancellationToken))
+            .Match(success => success, error => throw new InvalidOperationException($"Auth failed: {error.Message}"));
 
         if(!loginResult.Success || string.IsNullOrWhiteSpace(loginResult.HashedAccountId.Value))
             throw new InvalidOperationException("Failed to authenticate with OneDrive");
@@ -95,7 +98,8 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = (await authService.LoginAsync(TestContext.Current.CancellationToken))
+            .Match(success => success, error => throw new InvalidOperationException($"Auth failed: {error.Message}"));
 
         if(!loginResult.Success || string.IsNullOrWhiteSpace(loginResult.HashedAccountId.Value))
             throw new InvalidOperationException("Failed to authenticate with OneDrive");
@@ -125,12 +129,15 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = (await authService.LoginAsync(TestContext.Current.CancellationToken))
+            .Match(success => success, error => throw new InvalidOperationException($"Auth failed: {error.Message}"));
 
         if(!loginResult.Success || string.IsNullOrWhiteSpace(loginResult.HashedAccountId.Value))
             throw new InvalidOperationException("Failed to authenticate with OneDrive");
 
-        _ = await authService.GetAccessTokenAsync(loginResult.AccountId, TestContext.Current.CancellationToken) ?? throw new InvalidOperationException("Failed to get access token");
+        _ = (await authService.GetAccessTokenAsync(loginResult.AccountId, TestContext.Current.CancellationToken))
+            .Match(success => success, error => throw new InvalidOperationException($"Failed to get access token: {error.Message}"))
+            ?? throw new InvalidOperationException("Failed to get access token");
 
         var graphApiClient = new GraphApiClient(authService, null!, null!);
         var service = new FolderTreeService(graphApiClient, authService, null!);
@@ -151,12 +158,15 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = (await authService.LoginAsync(TestContext.Current.CancellationToken))
+            .Match(success => success, error => throw new InvalidOperationException($"Auth failed: {error.Message}"));
 
         if(!loginResult.Success || string.IsNullOrWhiteSpace(loginResult.HashedAccountId.Value))
             throw new InvalidOperationException("Failed to authenticate with OneDrive");
 
-        _ = await authService.GetAccessTokenAsync(loginResult.AccountId, TestContext.Current.CancellationToken) ?? throw new InvalidOperationException("Failed to get access token");
+        _ = (await authService.GetAccessTokenAsync(loginResult.AccountId, TestContext.Current.CancellationToken))
+            .Match(success => success, error => throw new InvalidOperationException($"Failed to get access token: {error.Message}"))
+            ?? throw new InvalidOperationException("Failed to get access token");
 
         var graphApiClient = new GraphApiClient(authService, null!, null!);
 

--- a/test/AStar.Dev.OneDrive.Sync.Client.Infrastructure.Tests.Unit/Services/OneDriveServices/FolderTreeServiceShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Infrastructure.Tests.Unit/Services/OneDriveServices/FolderTreeServiceShould.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Core;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models;
 using AStar.Dev.OneDrive.Sync.Client.Infrastructure.Services;
@@ -14,7 +15,7 @@ public class FolderTreeServiceShould
     {
         IGraphApiClient mockGraph = Substitute.For<IGraphApiClient>();
         IAuthService mockAuth = Substitute.For<IAuthService>();
-        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(false));
 
         var service = new FolderTreeService(mockGraph, mockAuth, null!);
 
@@ -30,7 +31,7 @@ public class FolderTreeServiceShould
     {
         IGraphApiClient mockGraph = Substitute.For<IGraphApiClient>();
         IAuthService mockAuth = Substitute.For<IAuthService>();
-        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(true));
 
         var driveItems = new List<DriveItem>
         {
@@ -59,7 +60,7 @@ public class FolderTreeServiceShould
     {
         IGraphApiClient mockGraph = Substitute.For<IGraphApiClient>();
         IAuthService mockAuth = Substitute.For<IAuthService>();
-        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(true));
 
         var driveItems = new List<DriveItem>
         {
@@ -81,7 +82,7 @@ public class FolderTreeServiceShould
     {
         IGraphApiClient mockGraph = Substitute.For<IGraphApiClient>();
         IAuthService mockAuth = Substitute.For<IAuthService>();
-        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(true));
 
         var parentItem = new DriveItem { Id = "parent1", Name = "Documents", ParentReference = new ItemReference { Path = "/drive/root:" } };
         _ = mockGraph.GetDriveItemAsync(Arg.Any<string>(), Arg.Any<HashedAccountId>(), "parent1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<DriveItem?>(parentItem));
@@ -106,7 +107,7 @@ public class FolderTreeServiceShould
     {
         IGraphApiClient mockGraph = Substitute.For<IGraphApiClient>();
         IAuthService mockAuth = Substitute.For<IAuthService>();
-        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(false));
 
         var service = new FolderTreeService(mockGraph, mockAuth, null!);
 
@@ -122,7 +123,7 @@ public class FolderTreeServiceShould
     {
         IGraphApiClient mockGraph = Substitute.For<IGraphApiClient>();
         IAuthService mockAuth = Substitute.For<IAuthService>();
-        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+        _ = mockAuth.IsAuthenticatedAsync("account1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(false));
 
         var service = new FolderTreeService(mockGraph, mockAuth, null!);
 
@@ -137,7 +138,7 @@ public class FolderTreeServiceShould
     {
         IGraphApiClient mockGraph = Substitute.For<IGraphApiClient>();
         IAuthService mockAuth = Substitute.For<IAuthService>();
-        _ = mockAuth.IsAuthenticatedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        _ = mockAuth.IsAuthenticatedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(true));
 
         var rootItems = new List<DriveItem> { new() { Id = "root1", Name = "Documents", Folder = new Folder() } };
         _ = mockGraph.GetRootChildrenAsync(Arg.Any<string>(), Arg.Any<HashedAccountId>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<IEnumerable<DriveItem>>(rootItems));

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Services/OneDriveServices/FolderTreeServiceIntegrationShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Integration/Services/OneDriveServices/FolderTreeServiceIntegrationShould.cs
@@ -51,10 +51,8 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
-
-        if(!loginResult.Success)
-            throw new InvalidOperationException("Failed to authenticate with OneDrive");
+        var result = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = result.Match(v => v, e => throw new InvalidOperationException($"Failed to authenticate with OneDrive: {e.Message}"));
 
         var graphApiClient = new GraphApiClient(authService, null!, null!);
         var service = new FolderTreeService(graphApiClient, authService, null!);
@@ -74,10 +72,8 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
-
-        if(!loginResult.Success)
-            throw new InvalidOperationException("Failed to authenticate with OneDrive");
+        var result = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = result.Match(v => v, e => throw new InvalidOperationException($"Failed to authenticate with OneDrive: {e.Message}"));
 
         var graphApiClient = new GraphApiClient(authService, null!, null!);
         var service = new FolderTreeService(graphApiClient, authService, null!);
@@ -88,7 +84,7 @@ public class FolderTreeServiceIntegrationShould
 
         OneDriveFolderNode parentFolder = rootFolders[0];
 
-        IReadOnlyList<OneDriveFolderNode> childFolders = await service.GetChildFoldersAsync(loginResult.AccountId, new HashedAccountId(AccountIdHasher.Hash(loginResult.AccountId)), parentFolder.DriveItemId, Arg.Any<bool?>(), TestContext.Current.CancellationToken);
+        IReadOnlyList<OneDriveFolderNode> childFolders = await service.GetChildFoldersAsync(loginResult.AccountId, new HashedAccountId(AccountIdHasher.Hash(loginResult.AccountId)), parentFolder.DriveItemId, null, TestContext.Current.CancellationToken);
 
         _ = childFolders.ShouldNotBeNull();
         if(childFolders.Count > 0)
@@ -105,10 +101,8 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
-
-        if(!loginResult.Success)
-            throw new InvalidOperationException("Failed to authenticate with OneDrive");
+        var result = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = result.Match(v => v, e => throw new InvalidOperationException($"Failed to authenticate with OneDrive: {e.Message}"));
 
         var graphApiClient = new GraphApiClient(authService, null!, null!);
         var service = new FolderTreeService(graphApiClient, authService, null!);
@@ -135,12 +129,11 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        var result = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = result.Match(v => v, e => throw new InvalidOperationException($"Failed to authenticate with OneDrive: {e.Message}"));
 
-        if(!loginResult.Success)
-            throw new InvalidOperationException("Failed to authenticate with OneDrive");
-
-        _ = await authService.GetAccessTokenAsync(loginResult.AccountId, TestContext.Current.CancellationToken) ?? throw new InvalidOperationException("Failed to get access token");
+        var tokenResult = await authService.GetAccessTokenAsync(loginResult.AccountId, TestContext.Current.CancellationToken);
+        _ = tokenResult.Match(v => v, e => throw new InvalidOperationException($"Failed to get access token: {e.Message}"));
 
         var graphApiClient = new GraphApiClient(authService, null!, null!);
         var service = new FolderTreeService(graphApiClient, authService, null!);
@@ -162,12 +155,11 @@ public class FolderTreeServiceIntegrationShould
     {
         AuthConfiguration config = LoadTestConfiguration();
         AuthService authService = await AuthService.CreateAsync(config);
-        AuthenticationResult loginResult = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        var result = await authService.LoginAsync(TestContext.Current.CancellationToken);
+        AuthenticationResult loginResult = result.Match(v => v, e => throw new InvalidOperationException($"Failed to authenticate with OneDrive: {e.Message}"));
 
-        if(!loginResult.Success)
-            throw new InvalidOperationException("Failed to authenticate with OneDrive");
-
-        _ = await authService.GetAccessTokenAsync(loginResult.AccountId, TestContext.Current.CancellationToken) ?? throw new InvalidOperationException("Failed to get access token");
+        var tokenResult = await authService.GetAccessTokenAsync(loginResult.AccountId, TestContext.Current.CancellationToken);
+        _ = tokenResult.Match(v => v, e => throw new InvalidOperationException($"Failed to get access token: {e.Message}"));
 
         var graphApiClient = new GraphApiClient(authService, null!, null!);
 

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountManagementIntegrationShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountManagementIntegrationShould.cs
@@ -1,3 +1,4 @@
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Core;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models;
@@ -58,7 +59,7 @@ public class AccountManagementIntegrationShould : IDisposable
     public async Task PersistNewAccountToDatabaseWhenAdded()
     {
         var authResult = new AuthenticationResult(true, "new-acc", new HashedAccountId(AccountIdHasher.Hash("new-acc")), "New User", null);
-        _ = _mockAuthService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
+        _ = _mockAuthService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
 
         using var viewModel = new AccountManagementViewModel(_mockAuthService, _accountRepository, _mockLogger);
         await Task.Delay(50, TestContext.Current.CancellationToken);
@@ -97,7 +98,7 @@ public class AccountManagementIntegrationShould : IDisposable
         await _accountRepository.AddAsync(account, TestContext.Current.CancellationToken);
 
         var authResult = new AuthenticationResult(true, "acc-login", new HashedAccountId(AccountIdHasher.Hash("acc-login")), "User", null);
-        _ = _mockAuthService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
+        _ = _mockAuthService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
 
         using var viewModel = new AccountManagementViewModel(_mockAuthService, _accountRepository, _mockLogger);
         await Task.Delay(50, TestContext.Current.CancellationToken);
@@ -117,7 +118,7 @@ public class AccountManagementIntegrationShould : IDisposable
         var account = new AccountInfo("acc-logout", new HashedAccountId(AccountIdHasher.Hash("acc-logout")), "User", "/path", true, null, null, false, false, 3, 50, 0);
         await _accountRepository.AddAsync(account, TestContext.Current.CancellationToken);
 
-        _ = _mockAuthService.LogoutAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        _ = _mockAuthService.LogoutAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(true));
 
         using var viewModel = new AccountManagementViewModel(_mockAuthService, _accountRepository, _mockLogger);
         await Task.Delay(50, TestContext.Current.CancellationToken);
@@ -135,8 +136,8 @@ public class AccountManagementIntegrationShould : IDisposable
     public async Task MaintainConsistencyBetweenViewModelAndDatabaseAfterMultipleOperations()
     {
         var authResult = new AuthenticationResult(true, "multi-acc", new HashedAccountId(AccountIdHasher.Hash("multi-acc")), "Multi User", null);
-        _ = _mockAuthService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
-        _ = _mockAuthService.LogoutAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        _ = _mockAuthService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
+        _ = _mockAuthService.LogoutAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(true));
 
         using var viewModel = new AccountManagementViewModel(_mockAuthService, _accountRepository, _mockLogger);
         await Task.Delay(50, TestContext.Current.CancellationToken);

--- a/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountManagementViewModelShould.cs
+++ b/test/AStar.Dev.OneDrive.Sync.Client.Tests.Unit/Accounts/AccountManagementViewModelShould.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using AStar.Dev.Functional.Extensions;
 using AStar.Dev.OneDrive.Sync.Client.Accounts;
 using AStar.Dev.OneDrive.Sync.Client.Core;
 using AStar.Dev.OneDrive.Sync.Client.Core.Models;
@@ -22,7 +23,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
         _logger = Substitute.For<ILogger<AccountManagementViewModel>>();
 
         _ = _accountRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<IReadOnlyList<AccountInfo>>([]));
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(new AuthenticationResult(false, string.Empty, new HashedAccountId(string.Empty), string.Empty, "Not configured")));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(new AuthenticationResult(false, string.Empty, new HashedAccountId(string.Empty), string.Empty, "Not configured")));
 
         _viewModel = new AccountManagementViewModel(_authService, _accountRepository, _logger);
     }
@@ -76,7 +77,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
     {
         var authResult = new AuthenticationResult(Success: true,AccountId: "account123",HashedAccountId: new HashedAccountId(AccountIdHasher.Hash("hash123")),DisplayName: "test@example.com",ErrorMessage: null
         );
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
 
         _ = _viewModel.AddAccountCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -91,7 +92,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
     public async Task CreateLocalSyncPathWithSanitizedDisplayName()
     {
         var authResult = new AuthenticationResult(Success: true,AccountId: "account123",HashedAccountId: new HashedAccountId(AccountIdHasher.Hash("hash123")),DisplayName: "user@domain.com",ErrorMessage: null);
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
 
         _ = _viewModel.AddAccountCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -106,7 +107,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
     public async Task ShowToastOnAddAccountFailure()
     {
         var authResult = new AuthenticationResult(Success: false,AccountId: string.Empty,HashedAccountId: new HashedAccountId(string.Empty),DisplayName: string.Empty,ErrorMessage: "Authentication failed");
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
 
         _ = _viewModel.AddAccountCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -153,7 +154,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
         _viewModel.Accounts.Add(account);
         _viewModel.SelectedAccount = account;
         var authResult = new AuthenticationResult(Success: true,AccountId: "id1",HashedAccountId: new HashedAccountId(AccountIdHasher.Hash("hash1")),DisplayName: "user@example.com",ErrorMessage: null);
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
 
         _ = _viewModel.LoginCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -169,7 +170,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
         _viewModel.Accounts.Add(account);
         _viewModel.SelectedAccount = account;
         var authResult = new AuthenticationResult(Success: false,AccountId: string.Empty,HashedAccountId: new HashedAccountId(string.Empty),DisplayName: string.Empty,ErrorMessage: "Login failed");
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
 
         _ = _viewModel.LoginCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -185,7 +186,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
         AccountInfo account = AccountInfo.Standard("id1", new HashedAccountId(AccountIdHasher.Hash("hash1")), "user@example.com", "/path") with { IsAuthenticated = true };
         _viewModel.Accounts.Add(account);
         _viewModel.SelectedAccount = account;
-        _ = _authService.LogoutAsync("id1", Arg.Any<CancellationToken>()).Returns(Task.FromResult(true));
+        _ = _authService.LogoutAsync("id1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(true));
 
         _ = _viewModel.LogoutCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -200,7 +201,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
         AccountInfo account = AccountInfo.Standard("id1", new HashedAccountId(AccountIdHasher.Hash("hash1")), "user@example.com", "/path") with { IsAuthenticated = true };
         _viewModel.Accounts.Add(account);
         _viewModel.SelectedAccount = account;
-        _ = _authService.LogoutAsync("id1", Arg.Any<CancellationToken>()).Returns(Task.FromResult(false));
+        _ = _authService.LogoutAsync("id1", Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<bool, ErrorResponse>>(false));
 
         _ = _viewModel.LogoutCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -306,7 +307,7 @@ public sealed class AccountManagementViewModelShould : IDisposable
     public async Task HideToastAfterFiveSeconds()
     {
         var authResult = new AuthenticationResult(Success: false,AccountId: string.Empty,HashedAccountId: new HashedAccountId(string.Empty),DisplayName: string.Empty,ErrorMessage: "Test error");
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult));
 
         _ = _viewModel.AddAccountCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
@@ -322,14 +323,14 @@ public sealed class AccountManagementViewModelShould : IDisposable
     public async Task CancelPreviousToastWhenShowingNewToast()
     {
         var authResult1 = new AuthenticationResult(Success: false,AccountId: string.Empty,HashedAccountId: new HashedAccountId(string.Empty),DisplayName: string.Empty,ErrorMessage: "First error");
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult1));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult1));
 
         _ = _viewModel.AddAccountCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
         _viewModel.ToastMessage.ShouldBe("First error");
         var authResult2 = new AuthenticationResult(Success: false,AccountId: string.Empty,HashedAccountId: new HashedAccountId(string.Empty),DisplayName: string.Empty,ErrorMessage: "Second error");
-        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult(authResult2));
+        _ = _authService.LoginAsync(Arg.Any<CancellationToken>()).Returns(Task.FromResult<Result<AuthenticationResult, ErrorResponse>>(authResult2));
         _ = _viewModel.AddAccountCommand.Execute().Subscribe();
         await Task.Delay(100, TestContext.Current.CancellationToken);
         _viewModel.ToastMessage.ShouldBe("Second error");

--- a/test/nuget-packages/AStar.Dev.Functional.Extensions.Tests.Unit/ConvenienceResultExtensionsShould.cs
+++ b/test/nuget-packages/AStar.Dev.Functional.Extensions.Tests.Unit/ConvenienceResultExtensionsShould.cs
@@ -1,3 +1,5 @@
+using AStar.Dev.Functional.Extensions;
+
 namespace AStar.Dev.Functional.Extensions.Tests.Unit;
 
 public class ConvenienceResultExtensionsShould


### PR DESCRIPTION
Refactor authentication handling in AccountManagementViewModel to use Result type for better error management

- Updated AccountManagementViewModel to utilize Result type for authentication results, enhancing error handling and readability.
- Introduced ConvenienceResultExtensions for easier handling of Result types in view models and tests.
- Modified tests across various services and view models to accommodate the new Result type, ensuring consistent error handling.
- Improved integration tests to validate authentication and access token retrieval using the Result type.